### PR TITLE
0: fix(shared): address metadata compile error

### DIFF
--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -17,11 +17,11 @@
 package org.http4s
 package googleapis.runtime
 
-import cats.effect.kernel.Temporal
-import org.http4s.client.Client
-import org.http4s.googleapis.runtime.auth.AccessToken
-import org.http4s.syntax.all._
-import org.typelevel.ci._
+import cats.effect.Temporal
+
+import client.Client
+import auth.AccessToken
+import syntax.all._
 
 trait ComputeMetadata[F[_]] {
   def getProjectId: F[String]
@@ -31,12 +31,17 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+  def getIdToken(audience: String): F[String]
 }
 
 object ComputeMetadata {
-  def apply[F[_]: Temporal](client: Client[F]): ComputeMetadata[F] =
+  def apply[F[_]: Temporal](
+      client: Client[F],
+      scopes: Set[String],
+      account: String = "default",
+  ): ComputeMetadata[F] =
     new ComputeMetadata[F] {
-      val headers = Headers(Header.Raw(ci"Metadata-Flavor", "Google"))
+      val headers = Headers("Metadata-Flavor" -> "Google")
       val baseUri: Uri = uri"http://metadata.google.internal/computeMetadata/v1"
       def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
 
@@ -48,20 +53,21 @@ object ComputeMetadata {
       val getClusterName = get("instance/attributes/cluster-name")
       val getContainerName = get("instance/attributes/container-name")
       val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
-    }
-}
-Metadata/v1"
-      def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
+      val getAccessToken = {
+        val base = baseUri / "instance" / "service-accounts" / account / "token"
+        val uri = if (scopes.isEmpty) {
+          base
+        } else {
+          base.withQueryParam("scopes", scopes.mkString(","))
+        }
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
 
-      def get(path: String) = client.expect[String](mkRequest(path))
+      def getIdToken(audience: String) = {
+        val uri = (baseUri / "instance" / "service-accounts" / account / "identity")
+          .withQueryParam("audience", audience)
 
-      val getProjectId = get("project/project-id")
-      val getZone = get("instance/zone")
-      val getInstanceId = get("instance/id")
-      val getClusterName = get("instance/attributes/cluster-name")
-      val getContainerName = get("instance/attributes/container-name")
-      val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
     }
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,7 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
-
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(


### PR DESCRIPTION
This commit
- addresses compile error in ComputeMetadata.scala.
- parameterizes account segment in uri in the same way as https://github.com/abdolence/gcloud-sdk-rs/blob/0c41f0685cbc2ed4d5cf4d9264e9830acaeb20ac/gcloud-sdk/src/token_source/metadata.rs#L32.
- adds `getIdToken` with the aim of adding external account auth support in the future. This change is done with reference to https://github.com/abdolence/gcloud-sdk-rs/blob/0c41f0685cbc2ed4d5cf4d9264e9830acaeb20ac/gcloud-sdk/src/token_source/metadata.rs#L47