### PR TITLE
1: Feat/add types for configuration JSON files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 ThisBuild / tlBaseVersion := "0.0"
 
-ThisBuild / organization := "io.chrisdavenport"
-ThisBuild / organizationName := "Christopher Davenport"
+ThisBuild / organization := "dev.i10416"
+ThisBuild / organizationName := "Yoichiro Ito"
 ThisBuild / developers := List(
+  tlGitHubDev("i10416", "Yoichiro Ito"),
   tlGitHubDev("christopherdavenport", "Christopher Davenport"),
   tlGitHubDev("armanbilge", "Arman Bilge"),
 )

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ ThisBuild / scalaVersion := Scala213
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 val http4sVersion = "0.23.23"
-
+val circeVersion = "0.14.6"
 lazy val root = tlCrossRootProject.aggregate(runtime)
 
 lazy val runtime = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -27,5 +27,8 @@ lazy val runtime = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "cats-effect" % "3.5.2",
       "org.http4s" %%% "http4s-client" % http4sVersion,
       "org.http4s" %%% "http4s-circe" % http4sVersion,
+      "io.circe" %%% "circe-core" % circeVersion,
+      "io.circe" %%% "circe-generic" % circeVersion,
+      "io.circe" %%% "circe-parser" % circeVersion,
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),
 )
 ThisBuild / tlCiReleaseBranches := Seq("main")
-ThisBuild / tlSonatypeUseLegacyHost := true
+//ThisBuild / tlSonatypeUseLegacyHost := true
 
 val Scala213 = "2.13.12"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.1")

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 ThisBuild / tlBaseVersion := "0.0"
 
-ThisBuild / organization := "dev.i10416"
-ThisBuild / organizationName := "Yoichiro Ito"
+ThisBuild / organization := "io.chrisdavenport"
+ThisBuild / organizationName := "Christopher Davenport"
 ThisBuild / developers := List(
-  tlGitHubDev("i10416", "Yoichiro Ito"),
   tlGitHubDev("christopherdavenport", "Christopher Davenport"),
   tlGitHubDev("armanbilge", "Arman Bilge"),
+  tlGitHubDev("i10416", "Yoichiro Ito"),
 )
 ThisBuild / tlCiReleaseBranches := Seq("main")
-//ThisBuild / tlSonatypeUseLegacyHost := true
+ThisBuild / tlSonatypeUseLegacyHost := true
 
 val Scala213 = "2.13.12"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.1")

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -17,11 +17,11 @@
 package org.http4s
 package googleapis.runtime
 
-import cats.effect.kernel.Temporal
-import org.http4s.client.Client
-import org.http4s.googleapis.runtime.auth.AccessToken
-import org.http4s.syntax.all._
-import org.typelevel.ci._
+import cats.effect.Temporal
+
+import client.Client
+import auth.AccessToken
+import syntax.all._
 
 trait ComputeMetadata[F[_]] {
   def getProjectId: F[String]
@@ -31,12 +31,17 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+  def getIdToken(audience: String): F[String]
 }
 
 object ComputeMetadata {
-  def apply[F[_]: Temporal](client: Client[F]): ComputeMetadata[F] =
+  def apply[F[_]: Temporal](
+      client: Client[F],
+      scopes: Set[String],
+      account: String = "default",
+  ): ComputeMetadata[F] =
     new ComputeMetadata[F] {
-      val headers = Headers(Header.Raw(ci"Metadata-Flavor", "Google"))
+      val headers = Headers("Metadata-Flavor" -> "Google")
       val baseUri: Uri = uri"http://metadata.google.internal/computeMetadata/v1"
       def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
 
@@ -48,20 +53,21 @@ object ComputeMetadata {
       val getClusterName = get("instance/attributes/cluster-name")
       val getContainerName = get("instance/attributes/container-name")
       val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
-    }
-}
-Metadata/v1"
-      def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
+      val getAccessToken = {
+        val base = baseUri / "instance" / "service-accounts" / account / "token"
+        val uri = if (scopes.isEmpty) {
+          base
+        } else {
+          base.withQueryParam("scopes", scopes.mkString(","))
+        }
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
 
-      def get(path: String) = client.expect[String](mkRequest(path))
+      def getIdToken(audience: String) = {
+        val uri = (baseUri / "instance" / "service-accounts" / account / "identity")
+          .withQueryParam("audience", audience)
 
-      val getProjectId = get("project/project-id")
-      val getZone = get("instance/zone")
-      val getInstanceId = get("instance/id")
-      val getClusterName = get("instance/attributes/cluster-name")
-      val getContainerName = get("instance/attributes/container-name")
-      val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
     }
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -31,6 +31,11 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+
+  /** Returns a Google ID Token from the metadata server on ComputeEngine
+    * @param audience
+    *   the aud: field the IdToken should include
+    */
   def getIdToken(audience: String): F[String]
 }
 

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -28,15 +28,11 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
-  private[auth] def withToken(token: String): AccessToken
-  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
 }
 
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
-    override private[auth] def withToken(newToken: String): AccessToken =
-      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -28,11 +28,15 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
+  private[auth] def withToken(token: String): AccessToken
+  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
 }
 
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
+    override private[auth] def withToken(newToken: String): AccessToken =
+      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -155,7 +155,7 @@ object CredentialsFile {
       implicit val ev: Decoder[ExternalCredentialUrlFormat] =
         Decoder
           .withReattempt(cursor =>
-            cursor.downField("type").as[String] match {
+            cursor.downField("type").as[String].map(_.toLowerCase()) match {
               case Right("json") =>
                 cursor.downField("subject_token_field_name").as[String].map(Json(_))
               case Right("text") => Right(Text)

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -76,9 +76,12 @@ object CredentialsFile {
 
   /** @param audience
     *   the Security Token Service audience, which is usually the fully specified resource name
-    *   of the workload/workforce pool provider
+    *   of the workload/workforce pool provider. This value exists for any credential source.
+    * @param subject_token_type
+    *   This value exists for any credential source.
     * @param token_url
-    *   the Security Token Service token exchange endpoint
+    *   the Security Token Service token exchange endpoint. This value exists for any credential
+    *   source.
     * @param token_info_url
     *   the endpoint used to retrieve account related information. Required for gCloud session
     *   account identification.
@@ -90,7 +93,7 @@ object CredentialsFile {
     *   the project used for quota and billing purposes.
     * @param credential_source
     *   This determines the source to obtain subject token. The value is either Url or File to
-    *   get subject token from.
+    *   get subject token from. This field helps detect the identity provider to use.
     * @param scopes
     *   the scopes to request during the authorization grant.
     */
@@ -114,10 +117,16 @@ object CredentialsFile {
     // #[serde(untagged)]
     object ExternalCredentialSource {
       implicit val ev: Decoder[ExternalCredentialSource] =
-        deriveDecoder[Url]
-          .widen[ExternalCredentialSource] <+> deriveDecoder[File]
-          .widen[ExternalCredentialSource] <+> implicitly[Decoder[Aws]]
-          .widen[ExternalCredentialSource]
+        // > This(file) should take precedence over url when both are provided.
+        deriveDecoder[File]
+          .widen[ExternalCredentialSource] <+>
+          deriveDecoder[Url]
+            .widen[ExternalCredentialSource] <+> implicitly[Decoder[Aws]]
+            .widen[ExternalCredentialSource]
+
+      /** @param url
+        *   a url to obtain subject token from
+        */
       case class Url(
           url: String,
           headers: Option[Map[String, String /*SecretValue*/ ]],
@@ -182,7 +191,7 @@ object CredentialsFile {
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(
-                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    s"Unexpected discriminator value `type`=$value for ExternalCredentialUrlFormat",
                     cursor.history,
                   ),
                 )

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -44,15 +44,23 @@ object CredentialsFile {
     deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
       .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
     /** service account credentials file containing __sensitive__ private key.
+      *
+      * @param client_id
+      *   Client id of the service account
+      * @param client_email
+      *   Client email address of the service account
+      * @param private_key_id
+      *   Private key identifier for the service account
+      * @param scopes
+      *   Scope strings for the APIs to be called.
       */
   final case class ServiceAccount(
       project_id: String,
       client_email: String,
       private val private_key_id: String,
       private[auth] val private_key: String, // SecretValue,
-      private val token_url: String,
-      // #[serde(skip)]
-      scopes: Seq[String],
+      private val token_uri: Option[String],
+      scopes: Option[Seq[String]],
       quota_project_id: Option[String],
   ) extends CredentialsFile
 
@@ -66,20 +74,36 @@ object CredentialsFile {
       `type`: String,
   ) extends CredentialsFile
 
-  /** @param credential_source
+  /** @param audience
+    *   the Security Token Service audience, which is usually the fully specified resource name
+    *   of the workload/workforce pool provider
+    * @param token_url
+    *   the Security Token Service token exchange endpoint
+    * @param token_info_url
+    *   the endpoint used to retrieve account related information. Required for gCloud session
+    *   account identification.
+    * @param service_account_impersonation_url
+    *   the URL for the service account impersonation request. This URL is required for some
+    *   APIs. If this URL is not available, the access token from the Security Token Service is
+    *   used directly. May be null.
+    * @param quota_project_id
+    *   the project used for quota and billing purposes.
+    * @param credential_source
     *   This determines the source to obtain subject token. The value is either Url or File to
     *   get subject token from.
+    * @param scopes
+    *   the scopes to request during the authorization grant.
     */
   final case class ExternalAccount(
       audience: String,
       subject_token_type: String,
       token_url: String,
+      token_info_url: String,
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
       credential_source: ExternalAccount.ExternalCredentialSource,
-      // #[serde(skip)]
-      scopes: Seq[String],
+      scopes: Option[Seq[String]],
   ) extends CredentialsFile
 
   object ExternalAccount {

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -19,6 +19,18 @@ package googleapis.runtime.auth
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+
+/** [[CredentialsFile]] represents Google application credentials file variants.
+  *
+  * CredentialsFile is one of the following;
+  *
+  *   - [[CredentialsFile.ServiceAccount]]: service account credentials file containing
+  *     __sensitive__ private key associated with a service account
+  *   - [[CredentialsFile.User]]: This file contains __sensitive__ oauth2 client secret and
+  *     refresh_token.
+  *   - [[CredentialsFile.ExternalAccount]]: This file contains only non-sensitive information.
+  *     This file is mainly for workload identity federation.
+  */
 sealed trait CredentialsFile extends Product with Serializable {
   def getQuotaProjectId: Option[String] = this match {
     case sa: CredentialsFile.ServiceAccount => sa.quota_project_id
@@ -31,6 +43,8 @@ object CredentialsFile {
   final implicit val ev: Decoder[CredentialsFile] =
     deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
       .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
+    /** service account credentials file containing __sensitive__ private key.
+      */
   final case class ServiceAccount(
       project_id: String,
       client_email: String,
@@ -41,6 +55,9 @@ object CredentialsFile {
       scopes: Seq[String],
       quota_project_id: Option[String],
   ) extends CredentialsFile
+
+  /** This file contains __sensitive__ oauth2 client secret and refresh token
+    */
   final case class User(
       private val client_secret: String, // SecretValue,
       client_id: String,
@@ -78,6 +95,12 @@ object CredentialsFile {
       ) extends ExternalCredentialSource
       // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
     }
+
+    /** Internally tagged union of the following two variants;
+      *
+      *   - `{"type": "json", "subject_token_field_name": "<string>"}`
+      *   - `{"type": "text"}`
+      */
     sealed trait ExternalCredentialUrlFormat
     object ExternalCredentialUrlFormat {
       implicit val ev: Decoder[ExternalCredentialUrlFormat] =
@@ -99,11 +122,18 @@ object CredentialsFile {
           )
           .widen[ExternalCredentialUrlFormat]
 
+      /** This variant indicates token value is JSON format.
+        * @param subject_token_field_name
+        *   This value is used to lookup token value from JSON object in token RPC response
+        */
       case class Json(subject_token_field_name: String) extends ExternalCredentialUrlFormat
+
+      /** This variant indicates token value is plain-text format.
+        */
       case object Text extends ExternalCredentialUrlFormat
     }
   }
-  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long])
+  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long /*u64*/ ])
   object ServiceAccountImpersonationSettings {
     implicit val ev: Decoder[ServiceAccountImpersonationSettings] = deriveDecoder
   }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -84,9 +84,9 @@ object CredentialsFile {
         Decoder
           .withReattempt(cursor =>
             cursor.downField("type").as[String] match {
-              case Right("Json") =>
+              case Right("json") =>
                 cursor.downField("subject_token_field_name").as[String].map(Json(_))
-              case Right("Text") => Right(Text)
+              case Right("text") => Right(Text)
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+sealed trait CredentialsFile extends Product with Serializable {
+  def getQuotaProjectId: Option[String] = this match {
+    case sa: CredentialsFile.ServiceAccount => sa.quota_project_id
+    case u: CredentialsFile.User => u.quota_project_id
+    case ea: CredentialsFile.ExternalAccount => ea.quota_project_id
+  }
+}
+
+object CredentialsFile {
+  final implicit val ev: Decoder[CredentialsFile] =
+    deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
+      .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
+  final case class ServiceAccount(
+      project_id: String,
+      client_email: String,
+      private val private_key_id: String,
+      private[auth] val private_key: String, // SecretValue,
+      private val token_url: String,
+      // #[serde(skip)]
+      scopes: Seq[String],
+      quota_project_id: Option[String],
+  ) extends CredentialsFile
+  final case class User(
+      private val client_secret: String, // SecretValue,
+      client_id: String,
+      private val refresh_token: String, // SecretValue,
+      quota_project_id: Option[String],
+  ) extends CredentialsFile
+  final case class ExternalAccount(
+      audience: String,
+      subject_token_type: String,
+      token_url: String,
+      service_account_impersonation_url: Option[String],
+      service_account_impersonation: Option[ServiceAccountImpersonationSettings],
+      quota_project_id: Option[String],
+      credential_source: ExternalAccount.ExternalCredentialSource,
+      // #[serde(skip)]
+      scopes: Seq[String],
+  ) extends CredentialsFile
+
+  object ExternalAccount {
+    sealed trait ExternalCredentialSource
+    // #[serde(untagged)]
+    object ExternalCredentialSource {
+      implicit val ev: Decoder[ExternalCredentialSource] =
+        deriveDecoder[Url]
+          .widen[ExternalCredentialSource] <+> deriveDecoder[File]
+          .widen[ExternalCredentialSource]
+      case class Url(
+          url: String,
+          headers: Option[Map[String, String /*SecretValue*/ ]],
+          format: Option[ExternalCredentialUrlFormat],
+      ) extends ExternalCredentialSource
+      case class File(
+          file: String,
+          format: Option[ExternalCredentialUrlFormat],
+      ) extends ExternalCredentialSource
+      // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
+    }
+    sealed trait ExternalCredentialUrlFormat
+    object ExternalCredentialUrlFormat {
+      implicit val ev: Decoder[ExternalCredentialUrlFormat] =
+        Decoder
+          .withReattempt(cursor =>
+            cursor.downField("type").as[String] match {
+              case Right("Json") =>
+                cursor.downField("subject_token_field_name").as[String].map(Json(_))
+              case Right("Text") => Right(Text)
+              case Right(value) =>
+                Left(
+                  io.circe.DecodingFailure(
+                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    cursor.history,
+                  ),
+                )
+              case Left(e) => Left(e)
+            },
+          )
+          .widen[ExternalCredentialUrlFormat]
+
+      case class Json(subject_token_field_name: String) extends ExternalCredentialUrlFormat
+      case object Text extends ExternalCredentialUrlFormat
+    }
+  }
+  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long])
+  object ServiceAccountImpersonationSettings {
+    implicit val ev: Decoder[ServiceAccountImpersonationSettings] = deriveDecoder
+  }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -71,6 +71,12 @@ object CredentialsFile {
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
+      /** This determines the source to obtain subject token. The value is one of the
+        * followings;
+        *
+        *   - Url: The client should send http request to the url to get subject token
+        *   - File: There's a local file that contains subject token
+        */
       credential_source: ExternalAccount.ExternalCredentialSource,
       // #[serde(skip)]
       scopes: Seq[String],

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -64,6 +64,11 @@ object CredentialsFile {
       private val refresh_token: String, // SecretValue,
       quota_project_id: Option[String],
   ) extends CredentialsFile
+
+  /** @param credential_source
+    *   This determines the source to obtain subject token. The value is either Url or File to
+    *   get subject token from.
+    */
   final case class ExternalAccount(
       audience: String,
       subject_token_type: String,
@@ -71,12 +76,6 @@ object CredentialsFile {
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
-      /** This determines the source to obtain subject token. The value is one of the
-        * followings;
-        *
-        *   - Url: The client should send http request to the url to get subject token
-        *   - File: There's a local file that contains subject token
-        */
       credential_source: ExternalAccount.ExternalCredentialSource,
       // #[serde(skip)]
       scopes: Seq[String],

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -63,6 +63,7 @@ object CredentialsFile {
       client_id: String,
       private val refresh_token: String, // SecretValue,
       quota_project_id: Option[String],
+      `type`: String,
   ) extends CredentialsFile
 
   /** @param credential_source

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -114,7 +114,6 @@ object CredentialsFile {
     /** Base credential source class. Dictates the retrieval method of the external credential.
       */
     sealed trait ExternalCredentialSource
-    // #[serde(untagged)]
     object ExternalCredentialSource {
       implicit val ev: Decoder[ExternalCredentialSource] =
         // > This(file) should take precedence over url when both are provided.
@@ -171,7 +170,6 @@ object CredentialsFile {
                 )
             }
       }
-      // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
     }
 
     /** Internally tagged union of the following two variants;

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.http4s
 package googleapis.runtime.auth
 
 import scodec.bits.ByteVector
-
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,7 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
-
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,8 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
 
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds local credentials source file schema as a sealead trait.

The schema is based on Java implementation and https://github.com/abdolence/gcloud-sdk-rs/blob/0c41f0685cbc2ed4d5cf4d9264e9830acaeb20ac/gcloud-sdk/src/token_source/credentials.rs#L14,
which supports not only service account auth, but also client_id and client_secret auth as well as external account auth.

Diffs between previous changes are here: https://github.com/i10416/googleapis-http4s-runtime/pull/9/files

depends on #10 