### PR TITLE
2-1: Feat/support oauth2 token exchange for AWS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ ThisBuild / scalaVersion := Scala213
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 val http4sVersion = "0.23.23"
-
+val circeVersion = "0.14.6"
 lazy val root = tlCrossRootProject.aggregate(runtime)
 
 lazy val runtime = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -27,5 +27,8 @@ lazy val runtime = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "cats-effect" % "3.5.2",
       "org.http4s" %%% "http4s-client" % http4sVersion,
       "org.http4s" %%% "http4s-circe" % http4sVersion,
+      "io.circe" %%% "circe-core" % circeVersion,
+      "io.circe" %%% "circe-generic" % circeVersion,
+      "io.circe" %%% "circe-parser" % circeVersion,
     ),
   )

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -17,11 +17,11 @@
 package org.http4s
 package googleapis.runtime
 
-import cats.effect.kernel.Temporal
-import org.http4s.client.Client
-import org.http4s.googleapis.runtime.auth.AccessToken
-import org.http4s.syntax.all._
-import org.typelevel.ci._
+import cats.effect.Temporal
+
+import client.Client
+import auth.AccessToken
+import syntax.all._
 
 trait ComputeMetadata[F[_]] {
   def getProjectId: F[String]
@@ -31,12 +31,17 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+  def getIdToken(audience: String): F[String]
 }
 
 object ComputeMetadata {
-  def apply[F[_]: Temporal](client: Client[F]): ComputeMetadata[F] =
+  def apply[F[_]: Temporal](
+      client: Client[F],
+      scopes: Set[String],
+      account: String = "default",
+  ): ComputeMetadata[F] =
     new ComputeMetadata[F] {
-      val headers = Headers(Header.Raw(ci"Metadata-Flavor", "Google"))
+      val headers = Headers("Metadata-Flavor" -> "Google")
       val baseUri: Uri = uri"http://metadata.google.internal/computeMetadata/v1"
       def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
 
@@ -48,20 +53,21 @@ object ComputeMetadata {
       val getClusterName = get("instance/attributes/cluster-name")
       val getContainerName = get("instance/attributes/container-name")
       val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
-    }
-}
-Metadata/v1"
-      def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
+      val getAccessToken = {
+        val base = baseUri / "instance" / "service-accounts" / account / "token"
+        val uri = if (scopes.isEmpty) {
+          base
+        } else {
+          base.withQueryParam("scopes", scopes.mkString(","))
+        }
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
 
-      def get(path: String) = client.expect[String](mkRequest(path))
+      def getIdToken(audience: String) = {
+        val uri = (baseUri / "instance" / "service-accounts" / account / "identity")
+          .withQueryParam("audience", audience)
 
-      val getProjectId = get("project/project-id")
-      val getZone = get("instance/zone")
-      val getInstanceId = get("instance/id")
-      val getClusterName = get("instance/attributes/cluster-name")
-      val getContainerName = get("instance/attributes/container-name")
-      val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
     }
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -31,6 +31,11 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+
+  /** Returns a Google ID Token from the metadata server on ComputeEngine
+    * @param audience
+    *   the aud: field the IdToken should include
+    */
   def getIdToken(audience: String): F[String]
 }
 

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -28,11 +28,15 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
+  private[auth] def withToken(token: String): AccessToken
+  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
 }
 
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
+    override private[auth] def withToken(newToken: String): AccessToken =
+      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -28,11 +28,14 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
+  private[auth] def withToken(token: String): AccessToken
 }
 
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
+    override private[auth] def withToken(newToken: String): AccessToken =
+      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -29,6 +29,7 @@ sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
   private[auth] def withToken(token: String): AccessToken
+  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
 }
 
 object AccessToken {

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s
 package googleapis.runtime.auth
 import cats.MonadThrow

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
@@ -1,0 +1,132 @@
+package org.http4s
+package googleapis.runtime.auth
+import cats.MonadThrow
+import cats.data.EitherT
+import cats.data.OptionT
+import cats.data.Validated.Invalid
+import cats.data.Validated.Valid
+import cats.effect.Temporal
+import cats.effect.std.Env
+import cats.syntax.all._
+
+import CredentialsFile.ExternalAccount.ExternalCredentialSource
+import client.Client
+object AwsCredentials extends AwsSubjectTokenProvider {
+
+  /** @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    * @return
+    *   authorization token with impersonation
+    */
+  def apply[F[_]: Env](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      aws: ExternalCredentialSource.Aws,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] =
+    for {
+      urls <- validateSource(aws)
+      (r_cred_verification_url, maybe_url, maybe_region_url, maybe_imdsv2_sess_t_url) = urls
+
+      region = lookupAwsRegion(maybe_region_url)
+      secCredsSource = lookupSecurityCredentials(maybe_url)
+      _ <- F.both(region, secCredsSource)
+      credentials <- ImpersonatedCredentials(
+        client,
+        id,
+        impersonationURL,
+        retrieveSubjectTokenForAWS(externalAccount.audience, r_cred_verification_url),
+        externalAccount,
+        scopes,
+      )
+    } yield credentials
+
+  /** Validate the host for the url, regional_url and imdsv2_session_token_url fields if they
+    * are provided. The host should either be 169.254.169.254 or fd00:ec2::254.
+    */
+  private def validateSource[F[_]](
+      aws: ExternalCredentialSource.Aws,
+  )(implicit F: MonadThrow[F]) = {
+    def pureFrom3[S, T, U](s: T, t: T, u: U) = F.pure((s, t, u))
+    val parseURLToVNec = Uri.fromString.andThen(_.toValidatedNec)
+    val validUrlsIfExist = (
+      aws.url.traverse(parseURLToVNec),
+      aws.region_url.traverse(parseURLToVNec),
+      aws.imdsv2_session_token_url.traverse(parseURLToVNec),
+    ).traverseN(pureFrom3)
+    for {
+      regional_cred_verification_url <- F.fromEither(
+        Uri.fromString(aws.regional_cred_verification_url),
+      )
+      validUrlsIfExist <- validUrlsIfExist
+      urls <- validUrlsIfExist match {
+        case Invalid(errors) =>
+          F.raiseError(
+            new IllegalArgumentException(
+              errors.map(_.message).mkString_("\n"),
+            ),
+          )
+        case Valid((maybe_url, maybe_r_url, maybe_imdsv2_sess_t_url)) =>
+          F.pure((maybe_url, maybe_r_url, maybe_imdsv2_sess_t_url))
+      }
+    } yield (
+      regional_cred_verification_url,
+      urls._1, // maybe_url
+      urls._2, // maybe_r_url
+      urls._3, // maybe_imdsv2_sess_t_url
+    )
+  }
+
+  /** Check the environment variables in the following order (AWS_REGION and then the
+    * AWS_DEFAULT_REGION) to determine the AWS region. If found, skip using the AWS metadata
+    * server to determine this value. If the region environment variables are not provided, use
+    * the region_url to determine the current AWS region. The API returns the zone name, e.g.
+    * us-east-1d. The region should be determined by stripping the last character, e.g.
+    * us-east-1.
+    */
+  private def lookupAwsRegion[F[_]: Env](
+      regionURL: Option[Uri],
+  )(implicit F: MonadThrow[F]) = EitherT
+    .fromOptionM(
+      awsRegionFromEnv,
+      F.fromOption(regionURL, ???), // flatMap(fetchAwsRegion)
+    )
+    .value
+
+  private def awsRegionFromEnv[F[_]: Env: MonadThrow]: F[Option[String]] =
+    (OptionT(Env[F].get("AWS_REGION")) <+> OptionT(
+      Env[F].get("AWS_DEFAULT_REGION"),
+    )).value
+
+  /** Check the environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and the optional
+    * AWS_SESSION_TOKEN for the AWS security credentials. If found, skip using the AWS metadata
+    * server to determine these values. If url is available and the security credentials
+    * environment variables are not provided: Call url to retrieve the attached AWS IAM role
+    * name to the current instance. Call url/$ROLE_NAME to get the access key, secret key and
+    * security token needed to sign the GetCallerIdentity request.
+    */
+  private def lookupSecurityCredentials[F[_]: Env](
+      maybeURL: Option[Uri],
+  )(implicit F: MonadThrow[F]) = EitherT
+    .fromOptionM(
+      lookupSecurityCredentialsEnvVars,
+      F.fromOption(maybeURL, ???), // flatMap(fetchSecCreds)
+    )
+    .value
+  private def lookupSecurityCredentialsEnvVars[F[_]: Env](implicit
+      F: MonadThrow[F],
+  ): F[Option[((String, String), Option[String])]] = {
+    val required = OptionT(Env[F].get("AWS_ACCESS_KEY_ID"))
+      .product(OptionT(Env[F].get("AWS_SECRET_ACCESS_KEY")))
+    val optional = OptionT.liftF(Env[F].get("AWS_SESSION_TOKEN"))
+    required.product(optional).value
+  }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
@@ -17,19 +17,11 @@
 package org.http4s
 package googleapis.runtime.auth
 import cats.MonadThrow
-import cats.data.EitherT
-import cats.data.OptionT
 import cats.data.Validated.Invalid
 import cats.data.Validated.Valid
-import cats.effect.Concurrent
 import cats.effect.Temporal
 import cats.effect.std.Env
 import cats.syntax.all._
-import fs2.io.IOException
-import io.circe.Decoder
-import org.http4s.headers.Accept
-
-import circe.jsonOf
 import CredentialsFile.ExternalAccount.ExternalCredentialSource
 import client.Client
 object AwsCredentials extends AwsSubjectTokenProvider {
@@ -56,16 +48,18 @@ object AwsCredentials extends AwsSubjectTokenProvider {
     for {
       urls <- validateSource(aws)
       (r_cred_verification_url, maybe_url, maybe_region_url, maybe_imdsv2_sess_t_url) = urls
-
-      region = lookupAwsRegion(client, maybe_region_url)
-      secCredsSource = lookupSecurityCredentials(client)(maybe_url)
-      signingProps <- F.both(region, secCredsSource)
-      (region, ((kid, secAccessKey), sessTkn)) = signingProps
       credentials <- ImpersonatedCredentials(
         client,
         id,
         impersonationURL,
-        retrieveSubjectTokenForAWS(client, externalAccount.audience, r_cred_verification_url),
+        retrieveSubjectTokenForAWS(
+          client,
+          externalAccount.audience,
+          maybe_imdsv2_sess_t_url,
+          maybe_region_url,
+          r_cred_verification_url,
+          maybe_url,
+        ),
         externalAccount,
         scopes,
       )
@@ -106,114 +100,4 @@ object AwsCredentials extends AwsSubjectTokenProvider {
       urls._3, // maybe_imdsv2_sess_t_url
     )
   }
-
-  /** Check the environment variables in the following order (AWS_REGION and then the
-    * AWS_DEFAULT_REGION) to determine the AWS region.
-    *
-    * If found, skip using the AWS metadata server to determine this value.
-    *
-    * If the region environment variables are not provided, use the region_url to determine the
-    * current AWS region. The API returns the zone name, e.g. us-east-1d. The region should be
-    * determined by stripping the last character, e.g. us-east-1.
-    * @return
-    *   aws region
-    */
-  private def lookupAwsRegion[F[_]: Env](
-      client: Client[F],
-      regionURL: Option[Uri],
-  )(implicit F: Concurrent[F]) = EitherT
-    .fromOptionM(
-      awsRegionFromEnv,
-      F.fromOption(
-        regionURL,
-        new IOException("Neither region_url nor AWS region from environment variable is found."),
-      ).flatMap(fetchAwsRegion(client)),
-    )
-    .merge[String]
-
-  private def awsRegionFromEnv[F[_]: Env: MonadThrow]: F[Option[String]] =
-    (OptionT(Env[F].get("AWS_REGION")) <+> OptionT(
-      Env[F].get("AWS_DEFAULT_REGION"),
-    )).value
-
-  private def fetchAwsRegion[F[_]: Concurrent](client: Client[F])(uri: Uri) =
-    client.expect[String](uri).map(_.dropRight(1))
-
-  /** Check the environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and the optional
-    * AWS_SESSION_TOKEN for the AWS security credentials. If found, skip using the AWS metadata
-    * server to determine these values.
-    *
-    * If url is available and the security credentials environment variables are not provided:
-    * Call url to retrieve the attached AWS IAM role name to the current instance. Call
-    * url/$ROLE_NAME to get the access key, secret key and security token needed to sign the
-    * GetCallerIdentity request.
-    *
-    * @return
-    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN. These values are
-    *   temporary credentials typically last for several hours.
-    */
-  private def lookupSecurityCredentials[F[_]: Env](client: Client[F])(
-      maybeURL: Option[Uri],
-  )(implicit F: Concurrent[F]): F[((String, String), Option[String])] = EitherT
-    .fromOptionM(
-      lookupSecurityCredentialsEnvVars,
-      F.fromOption(
-        maybeURL,
-        new IOException(
-          "Neither url nor AWS security credential from environment variables is found",
-        ),
-      ).flatMap(fetchAwsSecurityCredentials(client)),
-    )
-    .merge
-
-  /** @return
-    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN.
-    */
-  private def lookupSecurityCredentialsEnvVars[F[_]: Env](implicit
-      F: MonadThrow[F],
-  ): F[Option[((String, String), Option[String])]] = {
-    val required = OptionT(Env[F].get("AWS_ACCESS_KEY_ID"))
-      .product(OptionT(Env[F].get("AWS_SECRET_ACCESS_KEY")))
-    val optional = OptionT.liftF(Env[F].get("AWS_SESSION_TOKEN"))
-    required.product(optional).value
-  }
-
-  /** @return
-    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN.
-    */
-  private def fetchAwsSecurityCredentials[F[_]: Concurrent](
-      client: Client[F],
-  )(uri: Uri): F[((String, String), Option[String])] =
-    for {
-      awsRoleName <- client.expect[String](uri)
-      awsSecCreds <- client.expect[AwsSecurityCredentials](
-        Request[F](
-          uri = uri / awsRoleName,
-        ).putHeaders(Accept(MediaType.application.json)),
-      )
-    } yield ((awsSecCreds.AccessKeyId, awsSecCreds.SecretAccessKey), None)
-}
-
-/** Interface defining the AWS security-credentials endpoint response.
-  */
-private case class AwsSecurityCredentials(
-    Code: String,
-    LastUpdated: String,
-    Type: String,
-    AccessKeyId: String,
-    SecretAccessKey: String,
-    Token: String,
-    Expiration: String,
-)
-private object AwsSecurityCredentials {
-  implicit def ev2[F[_]: Concurrent]: EntityDecoder[F, AwsSecurityCredentials] = jsonOf
-  implicit val ev: Decoder[AwsSecurityCredentials] = Decoder.forProduct7(
-    "Code",
-    "LastUpdated",
-    "Type",
-    "AccessKeyId",
-    "SecretAccessKey",
-    "Token",
-    "Expiration",
-  )(AwsSecurityCredentials(_, _, _, _, _, _, _))
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsCredentials.scala
@@ -21,10 +21,15 @@ import cats.data.EitherT
 import cats.data.OptionT
 import cats.data.Validated.Invalid
 import cats.data.Validated.Valid
+import cats.effect.Concurrent
 import cats.effect.Temporal
 import cats.effect.std.Env
 import cats.syntax.all._
+import fs2.io.IOException
+import io.circe.Decoder
+import org.http4s.headers.Accept
 
+import circe.jsonOf
 import CredentialsFile.ExternalAccount.ExternalCredentialSource
 import client.Client
 object AwsCredentials extends AwsSubjectTokenProvider {
@@ -52,14 +57,15 @@ object AwsCredentials extends AwsSubjectTokenProvider {
       urls <- validateSource(aws)
       (r_cred_verification_url, maybe_url, maybe_region_url, maybe_imdsv2_sess_t_url) = urls
 
-      region = lookupAwsRegion(maybe_region_url)
-      secCredsSource = lookupSecurityCredentials(maybe_url)
-      _ <- F.both(region, secCredsSource)
+      region = lookupAwsRegion(client, maybe_region_url)
+      secCredsSource = lookupSecurityCredentials(client)(maybe_url)
+      signingProps <- F.both(region, secCredsSource)
+      (region, ((kid, secAccessKey), sessTkn)) = signingProps
       credentials <- ImpersonatedCredentials(
         client,
         id,
         impersonationURL,
-        retrieveSubjectTokenForAWS(externalAccount.audience, r_cred_verification_url),
+        retrieveSubjectTokenForAWS(client, externalAccount.audience, r_cred_verification_url),
         externalAccount,
         scopes,
       )
@@ -90,53 +96,79 @@ object AwsCredentials extends AwsSubjectTokenProvider {
               errors.map(_.message).mkString_("\n"),
             ),
           )
-        case Valid((maybe_url, maybe_r_url, maybe_imdsv2_sess_t_url)) =>
-          F.pure((maybe_url, maybe_r_url, maybe_imdsv2_sess_t_url))
+        case Valid((maybe_sec_creds_url, maybe_region_url, maybe_imdsv2_sess_t_url)) =>
+          F.pure((maybe_sec_creds_url, maybe_region_url, maybe_imdsv2_sess_t_url))
       }
     } yield (
       regional_cred_verification_url,
-      urls._1, // maybe_url
-      urls._2, // maybe_r_url
+      urls._1, // maybe_sec_creds_url
+      urls._2, // maybe_region_url
       urls._3, // maybe_imdsv2_sess_t_url
     )
   }
 
   /** Check the environment variables in the following order (AWS_REGION and then the
-    * AWS_DEFAULT_REGION) to determine the AWS region. If found, skip using the AWS metadata
-    * server to determine this value. If the region environment variables are not provided, use
-    * the region_url to determine the current AWS region. The API returns the zone name, e.g.
-    * us-east-1d. The region should be determined by stripping the last character, e.g.
-    * us-east-1.
+    * AWS_DEFAULT_REGION) to determine the AWS region.
+    *
+    * If found, skip using the AWS metadata server to determine this value.
+    *
+    * If the region environment variables are not provided, use the region_url to determine the
+    * current AWS region. The API returns the zone name, e.g. us-east-1d. The region should be
+    * determined by stripping the last character, e.g. us-east-1.
+    * @return
+    *   aws region
     */
   private def lookupAwsRegion[F[_]: Env](
+      client: Client[F],
       regionURL: Option[Uri],
-  )(implicit F: MonadThrow[F]) = EitherT
+  )(implicit F: Concurrent[F]) = EitherT
     .fromOptionM(
       awsRegionFromEnv,
-      F.fromOption(regionURL, ???), // flatMap(fetchAwsRegion)
+      F.fromOption(
+        regionURL,
+        new IOException("Neither region_url nor AWS region from environment variable is found."),
+      ).flatMap(fetchAwsRegion(client)),
     )
-    .value
+    .merge[String]
 
   private def awsRegionFromEnv[F[_]: Env: MonadThrow]: F[Option[String]] =
     (OptionT(Env[F].get("AWS_REGION")) <+> OptionT(
       Env[F].get("AWS_DEFAULT_REGION"),
     )).value
 
+  private def fetchAwsRegion[F[_]: Concurrent](client: Client[F])(uri: Uri) =
+    client.expect[String](uri).map(_.dropRight(1))
+
   /** Check the environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and the optional
     * AWS_SESSION_TOKEN for the AWS security credentials. If found, skip using the AWS metadata
-    * server to determine these values. If url is available and the security credentials
-    * environment variables are not provided: Call url to retrieve the attached AWS IAM role
-    * name to the current instance. Call url/$ROLE_NAME to get the access key, secret key and
-    * security token needed to sign the GetCallerIdentity request.
+    * server to determine these values.
+    *
+    * If url is available and the security credentials environment variables are not provided:
+    * Call url to retrieve the attached AWS IAM role name to the current instance. Call
+    * url/$ROLE_NAME to get the access key, secret key and security token needed to sign the
+    * GetCallerIdentity request.
+    *
+    * @return
+    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN. These values are
+    *   temporary credentials typically last for several hours.
     */
-  private def lookupSecurityCredentials[F[_]: Env](
+  private def lookupSecurityCredentials[F[_]: Env](client: Client[F])(
       maybeURL: Option[Uri],
-  )(implicit F: MonadThrow[F]) = EitherT
+  )(implicit F: Concurrent[F]): F[((String, String), Option[String])] = EitherT
     .fromOptionM(
       lookupSecurityCredentialsEnvVars,
-      F.fromOption(maybeURL, ???), // flatMap(fetchSecCreds)
+      F.fromOption(
+        maybeURL,
+        new IOException(
+          "Neither url nor AWS security credential from environment variables is found",
+        ),
+      ).flatMap(fetchAwsSecurityCredentials(client)),
     )
-    .value
+    .merge
+
+  /** @return
+    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN.
+    */
   private def lookupSecurityCredentialsEnvVars[F[_]: Env](implicit
       F: MonadThrow[F],
   ): F[Option[((String, String), Option[String])]] = {
@@ -145,4 +177,43 @@ object AwsCredentials extends AwsSubjectTokenProvider {
     val optional = OptionT.liftF(Env[F].get("AWS_SESSION_TOKEN"))
     required.product(optional).value
   }
+
+  /** @return
+    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN.
+    */
+  private def fetchAwsSecurityCredentials[F[_]: Concurrent](
+      client: Client[F],
+  )(uri: Uri): F[((String, String), Option[String])] =
+    for {
+      awsRoleName <- client.expect[String](uri)
+      awsSecCreds <- client.expect[AwsSecurityCredentials](
+        Request[F](
+          uri = uri / awsRoleName,
+        ).putHeaders(Accept(MediaType.application.json)),
+      )
+    } yield ((awsSecCreds.AccessKeyId, awsSecCreds.SecretAccessKey), None)
+}
+
+/** Interface defining the AWS security-credentials endpoint response.
+  */
+private case class AwsSecurityCredentials(
+    Code: String,
+    LastUpdated: String,
+    Type: String,
+    AccessKeyId: String,
+    SecretAccessKey: String,
+    Token: String,
+    Expiration: String,
+)
+private object AwsSecurityCredentials {
+  implicit def ev2[F[_]: Concurrent]: EntityDecoder[F, AwsSecurityCredentials] = jsonOf
+  implicit val ev: Decoder[AwsSecurityCredentials] = Decoder.forProduct7(
+    "Code",
+    "LastUpdated",
+    "Type",
+    "AccessKeyId",
+    "SecretAccessKey",
+    "Token",
+    "Expiration",
+  )(AwsSecurityCredentials(_, _, _, _, _, _, _))
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s
 package googleapis.runtime.auth
 import io.circe.Json

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
@@ -2,7 +2,9 @@ package org.http4s
 package googleapis.runtime.auth
 import io.circe.Json
 import io.circe.syntax._
+import io.circe.Printer
 import io.circe.Decoder
+import cats.Applicative
 private[auth] trait AwsSubjectTokenProvider {
 
   // The spec says
@@ -49,14 +51,20 @@ private[auth] trait AwsSubjectTokenProvider {
       ),
     ),
   )
-  private[auth] def retrieveSubjectTokenForAWS[F[_]]: F[String] =
+  private[auth] def retrieveSubjectTokenForAWS[F[_]](
+      audience: String,
+      r_cred_verification_url: Uri,
+  )(implicit F: Applicative[F]): F[String] = {
     // memonize AwsRequestSigner
     // getAwsRoleName
     // getAwsSecurityCredentials
     // Generate signed request to AWS STS GetCallerIdentity API.
-    // val json = mkSbjTkn
-    // encodeURIComponent(printer.noSpaces(json))
-    ???
+    val json = mkSbjTkn(???, audience)
+    // encodeURIComponent and then
+    F.pure(
+      Printer.noSpaces.print(json),
+    )
+  }
 }
 
 /** Interface defining the AWS security-credentials endpoint response.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
@@ -17,9 +17,9 @@
 package org.http4s
 package googleapis.runtime.auth
 import io.circe.Json
+import client.Client
 import io.circe.syntax._
 import io.circe.Printer
-import io.circe.Decoder
 import cats.Applicative
 private[auth] trait AwsSubjectTokenProvider {
 
@@ -68,6 +68,7 @@ private[auth] trait AwsSubjectTokenProvider {
     ),
   )
   private[auth] def retrieveSubjectTokenForAWS[F[_]](
+      client: Client[F],
       audience: String,
       r_cred_verification_url: Uri,
   )(implicit F: Applicative[F]): F[String] = {
@@ -81,27 +82,4 @@ private[auth] trait AwsSubjectTokenProvider {
       Printer.noSpaces.print(json),
     )
   }
-}
-
-/** Interface defining the AWS security-credentials endpoint response.
-  */
-private case class AwsSecurityCredentials(
-    Code: String,
-    LastUpdated: String,
-    Type: String,
-    AccessKeyId: String,
-    SecretAccessKey: String,
-    Token: String,
-    Expiration: String,
-)
-private object AwsSecurityCredentials {
-  implicit val ev: Decoder[AwsSecurityCredentials] = Decoder.forProduct7(
-    "Code",
-    "LastUpdated",
-    "Type",
-    "AccessKeyId",
-    "SecretAccessKey",
-    "Token",
-    "Expiration",
-  )(AwsSecurityCredentials(_, _, _, _, _, _, _))
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
@@ -1,0 +1,83 @@
+package org.http4s
+package googleapis.runtime.auth
+import io.circe.Json
+import io.circe.syntax._
+import io.circe.Decoder
+private[auth] trait AwsSubjectTokenProvider {
+
+  // The spec says
+  // > For the AWS token, STS requires a special header `x-goog-cloud-endpoint`
+  // > to recognize that the token is for a specific workload identity provider.
+  // However, both Node.js and Java implementation seem to ignore this spec.
+  // suppress warnings for now
+  private[auth] def requestOverride[F[_]]: Request[F] => Request[F] =
+    _.putHeaders("x-goog-cloud-endpoint" -> "???")
+
+  /** @param headers
+    *   request option headers from AWS STS GetCallerIdentity API
+    * @param audience
+    *   The full, canonical resource name of the workload identity pool provider, with or
+    *   without the HTTPS prefix.
+    *
+    * @return
+    *   subject token in JSON format
+    */
+  private def mkSbjTkn(headers: Map[String, String], audience: String): Json = Json.obj(
+    "url" -> headers("url").asJson,
+    "method" -> headers("method").asJson,
+    // The GCP STS endpoint expects the headers to be formatted as:
+    // [
+    //   {key: 'x-amz-date', value: '...'},
+    //   {key: 'Authorization', value: '...'},
+    //   ...
+    // ]
+    "headers" -> Json.fromValues(
+      headers.map(header =>
+        Json.obj(
+          "key" -> header._1.toString.asJson,
+          "value" -> header._2.toString.asJson,
+        ),
+      ) ++ Seq(
+        Json.obj(
+          "key" -> "x-goog-cloud-target-resource".asJson,
+          // The full, canonical resource name of the workload identity pool
+          // provider, with or without the HTTPS prefix.
+          // Including this header as part of the signature is recommended to
+          // ensure data integrity.
+          "value" -> audience.asJson,
+        ),
+      ),
+    ),
+  )
+  private[auth] def retrieveSubjectTokenForAWS[F[_]]: F[String] =
+    // memonize AwsRequestSigner
+    // getAwsRoleName
+    // getAwsSecurityCredentials
+    // Generate signed request to AWS STS GetCallerIdentity API.
+    // val json = mkSbjTkn
+    // encodeURIComponent(printer.noSpaces(json))
+    ???
+}
+
+/** Interface defining the AWS security-credentials endpoint response.
+  */
+private case class AwsSecurityCredentials(
+    Code: String,
+    LastUpdated: String,
+    Type: String,
+    AccessKeyId: String,
+    SecretAccessKey: String,
+    Token: String,
+    Expiration: String,
+)
+private object AwsSecurityCredentials {
+  implicit val ev: Decoder[AwsSecurityCredentials] = Decoder.forProduct7(
+    "Code",
+    "LastUpdated",
+    "Type",
+    "AccessKeyId",
+    "SecretAccessKey",
+    "Token",
+    "Expiration",
+  )(AwsSecurityCredentials(_, _, _, _, _, _, _))
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AwsSubjectTokenProvider.scala
@@ -16,33 +16,199 @@
 
 package org.http4s
 package googleapis.runtime.auth
+import cats.MonadThrow
+import cats.data.EitherT
+import cats.data.OptionT
+import cats.effect.Concurrent
+import cats.effect.std.Env
+import cats.syntax.all._
+import fs2.io.IOException
+import io.circe.Decoder
 import io.circe.Json
-import client.Client
-import io.circe.syntax._
 import io.circe.Printer
-import cats.Applicative
+import io.circe.syntax._
+import org.http4s.headers.Accept
+
+import java.net.URLEncoder
+
+import circe.jsonOf
+import client.Client
 private[auth] trait AwsSubjectTokenProvider {
+  def retrieveSubjectTokenForAWS[F[_]: Env](
+      client: Client[F],
+      audience: String,
+      maybe_region_uri: Option[Uri],
+      maybe_imdsv2_sess_t_url: Option[Uri],
+      r_cred_verification_url: Uri,
+      maybe_uri: Option[Uri],
+  )(implicit F: Concurrent[F]): F[String] = {
+    val imdsv2SessHeaders = mkImdsv2SessTokenHeaders(client, maybe_imdsv2_sess_t_url)
+    for {
+      pair <- F.both(
+        lookupAwsRegion(client, maybe_region_uri, imdsv2SessHeaders),
+        lookupSecurityCredentials(client, maybe_uri, imdsv2SessHeaders),
+      )
+      (region, secCreds) = pair
+      r_cred_v_url_with_region_substituted <-
+        F.fromEither(
+          Uri.fromString(
+            r_cred_verification_url.renderString.replace("{region}", region),
+          ),
+        )
+      _ = ("x-goog-cloud-target-resource" -> audience)
+      // signature <-  signer(r_cred_v_url_with_region_substituted,..).sign
+      json = mkSbjTkn(???, r_cred_v_url_with_region_substituted, audience)
+      // Generate signed request to AWS STS GetCallerIdentity API.
+    } yield URLEncoder.encode(Printer.noSpaces.print(json), "UTF-8")
+  }
 
-  // The spec says
-  // > For the AWS token, STS requires a special header `x-goog-cloud-endpoint`
-  // > to recognize that the token is for a specific workload identity provider.
-  // However, both Node.js and Java implementation seem to ignore this spec.
-  // suppress warnings for now
-  private[auth] def requestOverride[F[_]]: Request[F] => Request[F] =
-    _.putHeaders("x-goog-cloud-endpoint" -> "???")
+  // TODO: cache
+  /** Create HTTP headers for AWS metadata server if `imdsv2SessTokenURL` is present.
+    *
+    * > AWS IDMSv2 introduced a requirement for a session token to be present with the requests
+    * made to metadata endpoints. This requirement is to help prevent SSRF attacks. Presence of
+    * "imdsv2_session_token_url" in Credential Source of config file will trigger a flow with
+    * session token, else there will not be a session token with the metadata requests. Both
+    * flows work for IDMS v1 and v2. But if IDMSv2 is enabled, then if session token is not
+    * present, Unauthorized exception will be thrown.
+    *
+    * @see
+    *   https://github.com/googleapis/google-auth-library-java/blob/ab872812d0f6e9ad7598ba4c4c503d5bff6c2a2b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java#L229
+    */
+  private def mkImdsv2SessTokenHeaders[F[_]: Concurrent](
+      client: Client[F],
+      imdsv2SessTokenURL: Option[Uri],
+  ): F[Headers] = imdsv2SessTokenURL
+    .traverse(u =>
+      client.expect[String](
+        Request[F](method = Method.PUT, uri = u)
+          .putHeaders("x-aws-ec2-metadata-token-ttl-seconds" -> "300"),
+      ),
+    )
+    .map(_.fold(Headers.empty)(tkn => Headers("x-aws-ec2-metadata-token" -> tkn)))
 
-  /** @param headers
-    *   request option headers from AWS STS GetCallerIdentity API
-    * @param audience
-    *   The full, canonical resource name of the workload identity pool provider, with or
-    *   without the HTTPS prefix.
+  /** Check the environment variables in the following order (AWS_REGION and then the
+    * AWS_DEFAULT_REGION) to determine the AWS region.
+    *
+    * If found, skip using the AWS metadata server to determine this value.
+    *
+    * If the region environment variables are not provided, use the region_url to determine the
+    * current AWS region. The API returns the zone name, e.g. us-east-1d. The region should be
+    * determined by stripping the last character, e.g. us-east-1.
+    * @return
+    *   aws region
+    */
+  private def lookupAwsRegion[F[_]: Env](
+      client: Client[F],
+      regionURL: Option[Uri],
+      mkImdsv2SessTokenHeaders: F[Headers],
+  )(implicit F: Concurrent[F]) = EitherT
+    .fromOptionM(
+      awsRegionFromEnv,
+      F.fromOption(
+        regionURL,
+        new IOException(
+          "Unable to determine the AWS region. Neither region_url nor AWS region from environment variable is found.",
+        ),
+      ).flatMap(fetchAwsRegion(client)(_, mkImdsv2SessTokenHeaders)),
+    )
+    .merge[String]
+
+  private def awsRegionFromEnv[F[_]: Env: MonadThrow]: F[Option[String]] =
+    (OptionT(Env[F].get("AWS_REGION")) <+> OptionT(
+      Env[F].get("AWS_DEFAULT_REGION"),
+    )).value
+
+  private def fetchAwsRegion[F[_]: Concurrent](
+      client: Client[F],
+  )(uri: Uri, mkImdsv2SessTokenHeaders: F[Headers]) =
+    mkImdsv2SessTokenHeaders.flatMap(headers =>
+      client.expect[String](Request[F](uri = uri, headers = headers)).map(_.dropRight(1)),
+    )
+
+  /** Check the environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and the optional
+    * AWS_SESSION_TOKEN for the AWS security credentials. If found, skip using the AWS metadata
+    * server to determine these values.
+    *
+    * If url is available and the security credentials environment variables are not provided:
+    * Call url to retrieve the attached AWS IAM role name to the current instance. Call
+    * url/$ROLE_NAME to get the access key, secret key and security token needed to sign the
+    * GetCallerIdentity request.
+    *
+    * @param maybeURL
+    *   a url to fetch AwsSecurityCredentials
+    * @param imdsv2SessTokenURL
+    *   a url to fetch session token
+    * @return
+    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN. These values are
+    *   temporary credentials typically last for several hours.
+    */
+  private def lookupSecurityCredentials[F[_]: Env](
+      client: Client[F],
+      maybeURL: Option[Uri],
+      mkImdsv2SessTokenHeaders: F[Headers],
+  )(implicit F: Concurrent[F]): F[((String, String), Option[String])] = EitherT
+    .fromOptionM(
+      lookupSecurityCredentialsEnvVars,
+      F.fromOption(
+        maybeURL,
+        new IOException(
+          "Neither url nor AWS security credential from environment variables is found",
+        ),
+      ).flatMap(fetchAwsSecurityCredentials(client)(_, mkImdsv2SessTokenHeaders)),
+    )
+    .merge
+
+  /** @return
+    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN.
+    */
+  private def lookupSecurityCredentialsEnvVars[F[_]: Env](implicit
+      F: MonadThrow[F],
+  ): F[Option[((String, String), Option[String])]] = {
+    val required = OptionT(Env[F].get("AWS_ACCESS_KEY_ID"))
+      .product(OptionT(Env[F].get("AWS_SECRET_ACCESS_KEY")))
+    val optional = OptionT.liftF(Env[F].get("AWS_SESSION_TOKEN"))
+    required.product(optional).value
+  }
+
+  /** fetch AwsSecurityCredentials from metadata server
+    *
+    * @param uri
+    *   a url to fetch AwsSecurityCredentials
+    * @param imdsv2SessTokenURL
+    *   a url to fetch session token
     *
     * @return
-    *   subject token in JSON format
+    *   (AwsAccessKeyId,AwsSecretAccessKey) with optional AWS_SESSION_TOKEN.
     */
-  private def mkSbjTkn(headers: Map[String, String], audience: String): Json = Json.obj(
-    "url" -> headers("url").asJson,
-    "method" -> headers("method").asJson,
+  private def fetchAwsSecurityCredentials[F[_]](
+      client: Client[F],
+  )(uri: Uri, imdsv2SessTokenHeaders: F[Headers])(implicit
+      F: Concurrent[F],
+  ): F[((String, String), Option[String])] =
+    for {
+      imdsv2SessHeaders <- imdsv2SessTokenHeaders
+      // Retrieve the IAM role that is attached to the VM. This is required to retrieve the AWS
+      // security credentials.
+      awsRoleName <- client.expect[String](Request[F](uri = uri, headers = imdsv2SessHeaders))
+      // Retrieve the AWS security credentials by calling the endpoint specified by the credential
+      // source.
+      awsSecCreds <- client.expect[AwsSecurityCredentials](
+        Request[F](
+          uri = uri / awsRoleName,
+        ).putHeaders(Accept(MediaType.application.json))
+          .putHeaders(imdsv2SessHeaders),
+      )
+    } yield ((awsSecCreds.AccessKeyId, awsSecCreds.SecretAccessKey), None)
+
+  private def mkSbjTkn(
+      signature: Signature,
+      rCredVUrlWithRegionSubstituted: Uri,
+      audience: String,
+  ): Json = Json.obj(
+    "url" ->
+      rCredVUrlWithRegionSubstituted.renderString.asJson,
+    "method" -> signature.httpMethod.asJson,
     // The GCP STS endpoint expects the headers to be formatted as:
     // [
     //   {key: 'x-amz-date', value: '...'},
@@ -50,7 +216,7 @@ private[auth] trait AwsSubjectTokenProvider {
     //   ...
     // ]
     "headers" -> Json.fromValues(
-      headers.map(header =>
+      signature.canonicalHeaders.map(header =>
         Json.obj(
           "key" -> header._1.toString.asJson,
           "value" -> header._2.toString.asJson,
@@ -64,22 +230,61 @@ private[auth] trait AwsSubjectTokenProvider {
           // ensure data integrity.
           "value" -> audience.asJson,
         ),
+        Json.obj(
+          "key" -> "Authorization".asJson,
+          "value" -> signature.authorizationHeader.asJson,
+        ),
       ),
     ),
   )
-  private[auth] def retrieveSubjectTokenForAWS[F[_]](
-      client: Client[F],
-      audience: String,
-      r_cred_verification_url: Uri,
-  )(implicit F: Applicative[F]): F[String] = {
-    // memonize AwsRequestSigner
-    // getAwsRoleName
-    // getAwsSecurityCredentials
-    // Generate signed request to AWS STS GetCallerIdentity API.
-    val json = mkSbjTkn(???, audience)
-    // encodeURIComponent and then
-    F.pure(
-      Printer.noSpaces.print(json),
-    )
-  }
+  // The spec says
+  // > For the AWS token, STS requires a special header `x-goog-cloud-endpoint`
+  // > to recognize that the token is for a specific workload identity provider.
+  // However, both Node.js and Java implementation seem to ignore this spec.
+  // suppress warnings for now
+  private[auth] def requestOverride[F[_]]: Request[F] => Request[F] =
+    _.putHeaders("x-goog-cloud-endpoint" -> "???")
+
+  /** @param signature
+    * @param rCredVUrlWithRegionSubstituted
+    *   regional credential verification url with region substituted
+    * @param audience
+    *   The full, canonical resource name of the workload identity pool provider, with or
+    *   without the HTTPS prefix.
+    *
+    * @return
+    *   subject token in JSON format
+    */
 }
+
+/** Interface defining the AWS security-credentials endpoint response.
+  */
+private case class AwsSecurityCredentials(
+    Code: String,
+    LastUpdated: String,
+    Type: String,
+    AccessKeyId: String,
+    SecretAccessKey: String,
+    Token: String,
+    Expiration: String,
+)
+private object AwsSecurityCredentials {
+  implicit def ev2[F[_]: Concurrent]: EntityDecoder[F, AwsSecurityCredentials] = jsonOf
+  implicit val ev: Decoder[AwsSecurityCredentials] = Decoder.forProduct7(
+    "Code",
+    "LastUpdated",
+    "Type",
+    "AccessKeyId",
+    "SecretAccessKey",
+    "Token",
+    "Expiration",
+  )(AwsSecurityCredentials(_, _, _, _, _, _, _))
+}
+
+private case class Signature(
+    canonicalHeaders: Map[String, String],
+    authorizationHeader: String,
+    audience: String,
+    region: String,
+    httpMethod: String,
+)

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -155,7 +155,7 @@ object CredentialsFile {
       implicit val ev: Decoder[ExternalCredentialUrlFormat] =
         Decoder
           .withReattempt(cursor =>
-            cursor.downField("type").as[String] match {
+            cursor.downField("type").as[String].map(_.toLowerCase()) match {
               case Right("json") =>
                 cursor.downField("subject_token_field_name").as[String].map(Json(_))
               case Right("text") => Right(Text)

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -76,9 +76,12 @@ object CredentialsFile {
 
   /** @param audience
     *   the Security Token Service audience, which is usually the fully specified resource name
-    *   of the workload/workforce pool provider
+    *   of the workload/workforce pool provider. This value exists for any credential source.
+    * @param subject_token_type
+    *   This value exists for any credential source.
     * @param token_url
-    *   the Security Token Service token exchange endpoint
+    *   the Security Token Service token exchange endpoint. This value exists for any credential
+    *   source.
     * @param token_info_url
     *   the endpoint used to retrieve account related information. Required for gCloud session
     *   account identification.
@@ -90,7 +93,7 @@ object CredentialsFile {
     *   the project used for quota and billing purposes.
     * @param credential_source
     *   This determines the source to obtain subject token. The value is either Url or File to
-    *   get subject token from.
+    *   get subject token from. This field helps detect the identity provider to use.
     * @param scopes
     *   the scopes to request during the authorization grant.
     */
@@ -114,10 +117,16 @@ object CredentialsFile {
     // #[serde(untagged)]
     object ExternalCredentialSource {
       implicit val ev: Decoder[ExternalCredentialSource] =
-        deriveDecoder[Url]
-          .widen[ExternalCredentialSource] <+> deriveDecoder[File]
-          .widen[ExternalCredentialSource] <+> implicitly[Decoder[Aws]]
-          .widen[ExternalCredentialSource]
+        // > This(file) should take precedence over url when both are provided.
+        deriveDecoder[File]
+          .widen[ExternalCredentialSource] <+>
+          deriveDecoder[Url]
+            .widen[ExternalCredentialSource] <+> implicitly[Decoder[Aws]]
+            .widen[ExternalCredentialSource]
+
+      /** @param url
+        *   a url to obtain subject token from
+        */
       case class Url(
           url: String,
           headers: Option[Map[String, String /*SecretValue*/ ]],
@@ -182,7 +191,7 @@ object CredentialsFile {
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(
-                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    s"Unexpected discriminator value `type`=$value for ExternalCredentialUrlFormat",
                     cursor.history,
                   ),
                 )

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -44,15 +44,23 @@ object CredentialsFile {
     deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
       .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
     /** service account credentials file containing __sensitive__ private key.
+      *
+      * @param client_id
+      *   Client id of the service account
+      * @param client_email
+      *   Client email address of the service account
+      * @param private_key_id
+      *   Private key identifier for the service account
+      * @param scopes
+      *   Scope strings for the APIs to be called.
       */
   final case class ServiceAccount(
       project_id: String,
       client_email: String,
       private val private_key_id: String,
       private[auth] val private_key: String, // SecretValue,
-      private val token_url: String,
-      // #[serde(skip)]
-      scopes: Seq[String],
+      private val token_uri: Option[String],
+      scopes: Option[Seq[String]],
       quota_project_id: Option[String],
   ) extends CredentialsFile
 
@@ -66,20 +74,36 @@ object CredentialsFile {
       `type`: String,
   ) extends CredentialsFile
 
-  /** @param credential_source
+  /** @param audience
+    *   the Security Token Service audience, which is usually the fully specified resource name
+    *   of the workload/workforce pool provider
+    * @param token_url
+    *   the Security Token Service token exchange endpoint
+    * @param token_info_url
+    *   the endpoint used to retrieve account related information. Required for gCloud session
+    *   account identification.
+    * @param service_account_impersonation_url
+    *   the URL for the service account impersonation request. This URL is required for some
+    *   APIs. If this URL is not available, the access token from the Security Token Service is
+    *   used directly. May be null.
+    * @param quota_project_id
+    *   the project used for quota and billing purposes.
+    * @param credential_source
     *   This determines the source to obtain subject token. The value is either Url or File to
     *   get subject token from.
+    * @param scopes
+    *   the scopes to request during the authorization grant.
     */
   final case class ExternalAccount(
       audience: String,
       subject_token_type: String,
       token_url: String,
+      token_info_url: String,
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
       credential_source: ExternalAccount.ExternalCredentialSource,
-      // #[serde(skip)]
-      scopes: Seq[String],
+      scopes: Option[Seq[String]],
   ) extends CredentialsFile
 
   object ExternalAccount {

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -19,6 +19,18 @@ package googleapis.runtime.auth
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+
+/** [[CredentialsFile]] represents Google application credentials file variants.
+  *
+  * CredentialsFile is one of the following;
+  *
+  *   - [[CredentialsFile.ServiceAccount]]: service account credentials file containing
+  *     __sensitive__ private key associated with a service account
+  *   - [[CredentialsFile.User]]: This file contains __sensitive__ oauth2 client secret and
+  *     refresh_token.
+  *   - [[CredentialsFile.ExternalAccount]]: This file contains only non-sensitive information.
+  *     This file is mainly for workload identity federation.
+  */
 sealed trait CredentialsFile extends Product with Serializable {
   def getQuotaProjectId: Option[String] = this match {
     case sa: CredentialsFile.ServiceAccount => sa.quota_project_id
@@ -31,6 +43,8 @@ object CredentialsFile {
   final implicit val ev: Decoder[CredentialsFile] =
     deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
       .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
+    /** service account credentials file containing __sensitive__ private key.
+      */
   final case class ServiceAccount(
       project_id: String,
       client_email: String,
@@ -41,6 +55,9 @@ object CredentialsFile {
       scopes: Seq[String],
       quota_project_id: Option[String],
   ) extends CredentialsFile
+
+  /** This file contains __sensitive__ oauth2 client secret and refresh token
+    */
   final case class User(
       private val client_secret: String, // SecretValue,
       client_id: String,
@@ -78,6 +95,12 @@ object CredentialsFile {
       ) extends ExternalCredentialSource
       // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
     }
+
+    /** Internally tagged union of the following two variants;
+      *
+      *   - `{"type": "json", "subject_token_field_name": "<string>"}`
+      *   - `{"type": "text"}`
+      */
     sealed trait ExternalCredentialUrlFormat
     object ExternalCredentialUrlFormat {
       implicit val ev: Decoder[ExternalCredentialUrlFormat] =
@@ -99,11 +122,18 @@ object CredentialsFile {
           )
           .widen[ExternalCredentialUrlFormat]
 
+      /** This variant indicates token value is JSON format.
+        * @param subject_token_field_name
+        *   This value is used to lookup token value from JSON object in token RPC response
+        */
       case class Json(subject_token_field_name: String) extends ExternalCredentialUrlFormat
+
+      /** This variant indicates token value is plain-text format.
+        */
       case object Text extends ExternalCredentialUrlFormat
     }
   }
-  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long])
+  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long /*u64*/ ])
   object ServiceAccountImpersonationSettings {
     implicit val ev: Decoder[ServiceAccountImpersonationSettings] = deriveDecoder
   }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -84,9 +84,9 @@ object CredentialsFile {
         Decoder
           .withReattempt(cursor =>
             cursor.downField("type").as[String] match {
-              case Right("Json") =>
+              case Right("json") =>
                 cursor.downField("subject_token_field_name").as[String].map(Json(_))
-              case Right("Text") => Right(Text)
+              case Right("text") => Right(Text)
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+sealed trait CredentialsFile extends Product with Serializable {
+  def getQuotaProjectId: Option[String] = this match {
+    case sa: CredentialsFile.ServiceAccount => sa.quota_project_id
+    case u: CredentialsFile.User => u.quota_project_id
+    case ea: CredentialsFile.ExternalAccount => ea.quota_project_id
+  }
+}
+
+object CredentialsFile {
+  final implicit val ev: Decoder[CredentialsFile] =
+    deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
+      .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
+  final case class ServiceAccount(
+      project_id: String,
+      client_email: String,
+      private val private_key_id: String,
+      private[auth] val private_key: String, // SecretValue,
+      private val token_url: String,
+      // #[serde(skip)]
+      scopes: Seq[String],
+      quota_project_id: Option[String],
+  ) extends CredentialsFile
+  final case class User(
+      private val client_secret: String, // SecretValue,
+      client_id: String,
+      private val refresh_token: String, // SecretValue,
+      quota_project_id: Option[String],
+  ) extends CredentialsFile
+  final case class ExternalAccount(
+      audience: String,
+      subject_token_type: String,
+      token_url: String,
+      service_account_impersonation_url: Option[String],
+      service_account_impersonation: Option[ServiceAccountImpersonationSettings],
+      quota_project_id: Option[String],
+      credential_source: ExternalAccount.ExternalCredentialSource,
+      // #[serde(skip)]
+      scopes: Seq[String],
+  ) extends CredentialsFile
+
+  object ExternalAccount {
+    sealed trait ExternalCredentialSource
+    // #[serde(untagged)]
+    object ExternalCredentialSource {
+      implicit val ev: Decoder[ExternalCredentialSource] =
+        deriveDecoder[Url]
+          .widen[ExternalCredentialSource] <+> deriveDecoder[File]
+          .widen[ExternalCredentialSource]
+      case class Url(
+          url: String,
+          headers: Option[Map[String, String /*SecretValue*/ ]],
+          format: Option[ExternalCredentialUrlFormat],
+      ) extends ExternalCredentialSource
+      case class File(
+          file: String,
+          format: Option[ExternalCredentialUrlFormat],
+      ) extends ExternalCredentialSource
+      // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
+    }
+    sealed trait ExternalCredentialUrlFormat
+    object ExternalCredentialUrlFormat {
+      implicit val ev: Decoder[ExternalCredentialUrlFormat] =
+        Decoder
+          .withReattempt(cursor =>
+            cursor.downField("type").as[String] match {
+              case Right("Json") =>
+                cursor.downField("subject_token_field_name").as[String].map(Json(_))
+              case Right("Text") => Right(Text)
+              case Right(value) =>
+                Left(
+                  io.circe.DecodingFailure(
+                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    cursor.history,
+                  ),
+                )
+              case Left(e) => Left(e)
+            },
+          )
+          .widen[ExternalCredentialUrlFormat]
+
+      case class Json(subject_token_field_name: String) extends ExternalCredentialUrlFormat
+      case object Text extends ExternalCredentialUrlFormat
+    }
+  }
+  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long])
+  object ServiceAccountImpersonationSettings {
+    implicit val ev: Decoder[ServiceAccountImpersonationSettings] = deriveDecoder
+  }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -71,6 +71,12 @@ object CredentialsFile {
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
+      /** This determines the source to obtain subject token. The value is one of the
+        * followings;
+        *
+        *   - Url: The client should send http request to the url to get subject token
+        *   - File: There's a local file that contains subject token
+        */
       credential_source: ExternalAccount.ExternalCredentialSource,
       // #[serde(skip)]
       scopes: Seq[String],

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -64,6 +64,11 @@ object CredentialsFile {
       private val refresh_token: String, // SecretValue,
       quota_project_id: Option[String],
   ) extends CredentialsFile
+
+  /** @param credential_source
+    *   This determines the source to obtain subject token. The value is either Url or File to
+    *   get subject token from.
+    */
   final case class ExternalAccount(
       audience: String,
       subject_token_type: String,
@@ -71,12 +76,6 @@ object CredentialsFile {
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
-      /** This determines the source to obtain subject token. The value is one of the
-        * followings;
-        *
-        *   - Url: The client should send http request to the url to get subject token
-        *   - File: There's a local file that contains subject token
-        */
       credential_source: ExternalAccount.ExternalCredentialSource,
       // #[serde(skip)]
       scopes: Seq[String],

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -63,6 +63,7 @@ object CredentialsFile {
       client_id: String,
       private val refresh_token: String, // SecretValue,
       quota_project_id: Option[String],
+      `type`: String,
   ) extends CredentialsFile
 
   /** @param credential_source

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -191,7 +191,7 @@ object CredentialsFile {
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(
-                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    s"Unexpected discriminator value `type`=$value for ExternalCredentialUrlFormat",
                     cursor.history,
                   ),
                 )

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountCredentials.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import client.Client
+import org.http4s.googleapis.runtime.auth.CredentialsFile
+import fs2.io.file.Files
+import cats.effect.Temporal
+import cats.syntax.all._
+import org.http4s.googleapis.runtime.auth.CredentialsFile.ExternalAccount.ExternalCredentialSource
+
+/** External account credentials(A.K.A Workload Identity Federation) implementation to access
+  * Google cloud resources from non-Google cloud platforms.
+  *
+  * @see
+  *   https://google.aip.dev/auth/4117
+  */
+object ExternalAccountCredentials {
+  final val DEFAULT_SCOPES = Seq("https://www.googleapis.com/auth/cloud-platform")
+
+  /** Create Google credentials for external account. Internally, ExternalAccountCredentials has
+    * the following variants
+    *
+    *   - IdentityPoolCredentials with and without service account impersonation from file or
+    *     url source
+    *   - AwsCredentials
+    *   - Plug-ableAuthCredentials
+    *
+    * @param externalAccount
+    *   credentials file to create ExternalAccountCredentials
+    * @param scopes
+    *   optional scope override. When it is empty, it uses scopes in credentials configuration
+    *   file or fallbacks to `DEFAULT_SCOPES`.
+    */
+  def apply[F[_]: Files](
+      client: Client[F],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Option[Seq[String]] = None,
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = {
+    val pid: F[String] = externalAccount.quota_project_id match {
+      case Some(id) => F.pure(id)
+      case None => ??? // fetch from metadata server?
+    }
+
+    for {
+      id <- pid
+      theScopes = scopes.orElse(externalAccount.scopes).getOrElse(DEFAULT_SCOPES)
+      impersonationURL <- externalAccount.service_account_impersonation_url.traverse(
+        Uri.fromString.andThen(F.fromEither),
+      )
+      // > check `credentials_source` to determine the necessary logic to retrieve the external credential
+      credentials <-
+        externalAccount.credential_source match {
+          case (f: ExternalCredentialSource.File) =>
+            IdentityPoolCredentials.fromFile(
+              client,
+              id,
+              impersonationURL,
+              f,
+              externalAccount,
+              theScopes,
+            )
+          case (u: ExternalCredentialSource.Url) =>
+            IdentityPoolCredentials.fromURL(
+              client,
+              id,
+              impersonationURL,
+              u,
+              externalAccount,
+              theScopes,
+            )
+          case (aws: ExternalCredentialSource.Aws) =>
+            IdentityPoolCredentials.forAWS(
+              client,
+              id,
+              impersonationURL,
+              aws,
+              externalAccount,
+              theScopes,
+            )
+        }
+    } yield credentials
+  }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountSubjectTokenProvider.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.io.file.Files
+import fs2.io.file.Path
+import io.circe.Decoder
+import io.circe.parser
+import org.http4s.circe.jsonOf
+
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.Text
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.{Json => JsonFmt}
+import client.Client
+private[auth] trait ExternalAccountSubjectTokenProvider {
+  private[auth] def subjectTokenFromUrl[F[_]](
+      client: Client[F],
+      url: Uri,
+      headers: Option[Map[String, String]],
+      format: Option[ExternalCredentialUrlFormat],
+  )(implicit F: Concurrent[F]) = {
+    val headerList = headers.getOrElse(Map.empty).toList
+    val hs = Headers(headerList)
+    val req = Request[F](uri = url).putHeaders(hs)
+    format match {
+      // > If the format is not available, assume the external credential is provided in plain text format
+      case None | Some(Text) => client.expect[String](req)
+      case Some(JsonFmt(subjectTokenFieldName)) =>
+        val dec = Decoder.forProduct1[String, String](subjectTokenFieldName)(identity)
+        client.expect[String](req)(jsonOf(F, dec))
+    }
+  }
+  private[auth] def subjectTokenFromFile[F[_]: Files](
+      file: String,
+      format: Option[ExternalCredentialUrlFormat],
+  )(implicit F: Concurrent[F]) = for {
+    tokenOrJson <- Files[F].readUtf8(Path(file)).compile.string
+    tkn <- format match {
+      // > If the format is not available, assume the external credential is provided in plain text format
+      case None | Some(Text) => F.pure(tokenOrJson)
+      case Some(JsonFmt(subjectTokenFieldName)) =>
+        val dec = Decoder.forProduct1[String, String](subjectTokenFieldName)(identity)
+        F.fromEither(parser.parse(tokenOrJson).flatMap(dec.decodeJson(_)))
+    }
+  } yield tkn
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.googleapis.runtime.auth
+
+trait GoogleCredentials[F[_]] {
+  def projectId: String
+  def get: F[AccessToken]
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2JwtBearer.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2JwtBearer.scala
@@ -19,7 +19,7 @@ package googleapis.runtime.auth
 
 import scodec.bits.ByteVector
 
-trait OAuth2[F[_]] {
+trait GoogleOAuth2JwtBearer[F[_]] {
   def getAccessToken(
       clientEmail: String,
       privateKey: ByteVector,

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
@@ -38,6 +38,11 @@ import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.Text
 import client.Client
 trait GoogleOAuth2TokenExchange[F[_]] {
   def subjectToken(externalAccount: CredentialsFile.ExternalAccount): F[String]
+
+  /** Exchanges the external credential for a Google Cloud access token.
+    * @return
+    *   the access token returned by the Security Token Service
+    */
   def stsToken(
       sbjToken: String,
       externalAccount: CredentialsFile.ExternalAccount,

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+
+import cats.effect.Concurrent
+import cats.effect.Temporal
+import cats.syntax.all._
+import fs2.io.file.Files
+import fs2.io.file.Path
+import io.circe.Decoder
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.parser
+import org.http4s.circe.jsonEncoderOf
+import org.http4s.circe.jsonOf
+import org.http4s.headers.Authorization
+
+import CredentialsFile.ExternalAccount.ExternalCredentialSource._
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.{Json => JsonFmt}
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.Text
+import client.Client
+trait GoogleOAuth2TokenExchange[F[_]] {
+  def subjectToken(externalAccount: CredentialsFile.ExternalAccount): F[String]
+  def stsToken(
+      sbjToken: String,
+      externalAccount: CredentialsFile.ExternalAccount,
+  ): F[AccessToken]
+}
+
+object GoogleOAuth2TokenExchange {
+  def apply[F[_]: Files: Temporal](client: Client[F]) =
+    new GoogleOAuth2TokenExchange[F] {
+      private val je: EntityEncoder[F, JsonObject] = jsonEncoderOf[F, JsonObject]
+      def subjectToken(externalAccount: CredentialsFile.ExternalAccount): F[String] =
+        externalAccount.credential_source match {
+          case Url(url, headers, format) => subjectTokenFromUrl(client, url, headers, format)
+          case File(file, format) => subjectTokenFromFile(file, format)
+        }
+      def stsToken(
+          sbjToken: String,
+          externalAccount: CredentialsFile.ExternalAccount,
+      ): F[AccessToken] = {
+        val scopes =
+          externalAccount.service_account_impersonation_url.fold(externalAccount.scopes)(_ =>
+            Seq("https://www.googleapis.com/auth/cloud-platform"),
+          )
+        val req = Request[F](uri = Uri.unsafeFromString(externalAccount.token_url))
+          .withEntity(
+            JsonObject(
+              "grant_type" -> Json.fromString(
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+              ),
+              "audience" -> Json.fromString(externalAccount.audience),
+              "requested_token_type" -> Json.fromString(
+                "urn:ietf:params:oauth:token-type:access_token",
+              ),
+              "subject_token_type" -> Json.fromString(externalAccount.subject_token_type),
+              "subject_token" -> Json.fromString(sbjToken),
+              "scope" -> Json.fromString(scopes.mkString(" ")),
+            ),
+          )(je)
+        val stsTkn = client.expect[AccessToken](req)
+
+        externalAccount.service_account_impersonation_url match {
+          case None => stsTkn
+          case Some(url) =>
+            val req = Request[F]()
+              .withUri(Uri.unsafeFromString(url))
+              .withMethod(Method.POST)
+              .withEntity(
+                JsonObject(
+                  "scopes" -> Json.fromString(externalAccount.scopes.mkString(",")),
+                ),
+              )(je)
+            val bearer = (tkn: AccessToken) => Credentials.Token(AuthScheme.Bearer, tkn.token)
+            for {
+              tkn <- stsTkn
+              tkn <- client.expect[AccessToken](
+                req.withHeaders(Authorization(bearer(tkn))),
+              )
+            } yield tkn
+        }
+      }
+    }
+  private def subjectTokenFromUrl[F[_]](
+      client: Client[F],
+      url: String,
+      headers: Option[Map[String, String]],
+      format: Option[ExternalCredentialUrlFormat],
+  )(implicit F: Concurrent[F]) = {
+    val headerList = headers.getOrElse(Map.empty).toList
+    val hs = Headers(headerList)
+    val uri = Uri.unsafeFromString(url)
+    val req = Request[F](uri = uri).putHeaders(hs)
+    format match {
+      case None | Some(Text) => client.expect[String](req)
+      case Some(JsonFmt(subjectTokenFieldName)) =>
+        val dec = Decoder.forProduct1[String, String](subjectTokenFieldName)(identity)
+        client.expect[String](req)(jsonOf(F, dec))
+    }
+  }
+  private def subjectTokenFromFile[F[_]: Files](
+      file: String,
+      format: Option[ExternalCredentialUrlFormat],
+  )(implicit F: Concurrent[F]) = for {
+    tokenOrJson <- Files[F].readUtf8(Path(file)).compile.string
+    tkn <- format match {
+      case None | Some(Text) => F.pure(tokenOrJson)
+      case Some(JsonFmt(subjectTokenFieldName)) =>
+        val dec = Decoder.forProduct1[String, String](subjectTokenFieldName)(identity)
+        F.fromEither(parser.parse(tokenOrJson).flatMap(dec.decodeJson(_)))
+    }
+  } yield tkn
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
@@ -17,17 +17,12 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.effect.Concurrent
 import cats.effect.Temporal
-
-import io.circe.Decoder
 import io.circe.Json
 import io.circe.JsonObject
-import io.circe.generic.semiauto.deriveDecoder
 import org.http4s.circe.jsonEncoderOf
-import org.http4s.circe.jsonOf
-import googleapis.runtime.auth.CredentialsFile.ExternalAccount
 
+import googleapis.runtime.auth.CredentialsFile.ExternalAccount
 import client.Client
 trait GoogleOAuth2TokenExchange[F[_]] {
 
@@ -80,20 +75,4 @@ object GoogleOAuth2TokenExchange {
         client.expect[AccessToken](requestOverride(req))
       }
     }
-}
-
-/** @param accessToken
-  *   access token
-  * @param expireTime
-  *   DateTime string in utc
-  */
-private[auth] case class IamCredentialsTokenResponse(
-    accessToken: String, // SecretValue,
-    expireTime: String,
-)
-
-private[auth] object IamCredentialsTokenResponse {
-  implicit def ed[F[_]: Concurrent]: EntityDecoder[F, IamCredentialsTokenResponse] =
-    jsonOf[F, IamCredentialsTokenResponse]
-  implicit val ev: Decoder[IamCredentialsTokenResponse] = deriveDecoder
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
@@ -57,6 +57,8 @@ object GoogleOAuth2TokenExchange {
         externalAccount.credential_source match {
           case Url(url, headers, format) => subjectTokenFromUrl(client, url, headers, format)
           case File(file, format) => subjectTokenFromFile(file, format)
+          case Aws(_, _, _, _, _) =>
+            throw new NotImplementedError("AWS credential source is not implemented yet.")
         }
       def stsToken(
           sbjToken: String,
@@ -64,7 +66,7 @@ object GoogleOAuth2TokenExchange {
       ): F[AccessToken] = {
         val scopes =
           externalAccount.service_account_impersonation_url.fold(externalAccount.scopes)(_ =>
-            Seq("https://www.googleapis.com/auth/cloud-platform"),
+            Some(Seq("https://www.googleapis.com/auth/cloud-platform")),
           )
         val req = Request[F](uri = Uri.unsafeFromString(externalAccount.token_url))
           .withEntity(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
@@ -29,6 +29,11 @@ import CredentialsFile.ExternalAccount.ExternalCredentialSource
 import fs2.io.file.Files
 import fs2.io.file.Path
 import fs2.io.IOException
+import cats.effect.Concurrent
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import org.http4s.circe.jsonOf
 
 object IdentityPoolCredentials
     extends ExternalAccountSubjectTokenProvider
@@ -246,4 +251,20 @@ object IdentityPoolCredentials
           iamTkn <- client.expect[IamCredentialsTokenResponse](req)
         } yield stsTkn.withToken(iamTkn.accessToken)
     }
+}
+
+/** @param accessToken
+  *   access token
+  * @param expireTime
+  *   DateTime string in utc
+  */
+private case class IamCredentialsTokenResponse(
+    accessToken: String, // SecretValue,
+    expireTime: String,
+)
+
+private object IamCredentialsTokenResponse {
+  implicit def ed[F[_]: Concurrent]: EntityDecoder[F, IamCredentialsTokenResponse] =
+    jsonOf[F, IamCredentialsTokenResponse]
+  implicit val ev: Decoder[IamCredentialsTokenResponse] = deriveDecoder
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+
+import cats.effect.Temporal
+import cats.syntax.all._
+
+import client.Client
+import io.circe.JsonObject
+import io.circe.Json
+import org.http4s.circe.jsonEncoderOf
+import org.http4s.headers.Authorization
+import CredentialsFile.ExternalAccount.ExternalCredentialSource
+import fs2.io.file.Files
+import fs2.io.file.Path
+import fs2.io.IOException
+
+object IdentityPoolCredentials
+    extends ExternalAccountSubjectTokenProvider
+    with AwsSubjectTokenProvider {
+  private final val PLATFORM_SCOPES = Seq("https://www.googleapis.com/auth/cloud-platform")
+  // private final val IAM_SCOPES = Seq("https://www.googleapis.com/auth/iam")
+
+  /** Create Google credentials from local file. The main use-case of this credentials is
+    * Workload Identity Federation. This function may fail when no file is found at file source.
+    */
+  private[auth] def fromFile[F[_]: Files](
+      client: Client[F],
+      projectId: String,
+      impersonationURL: Option[Uri],
+      fileSource: ExternalCredentialSource.File,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = (fileSource, impersonationURL) match {
+    case (file, Some(url)) =>
+      withImpersonation(client, projectId, url, file, externalAccount, scopes)
+    case (file, None) => withoutImpersonation(client, projectId, file, externalAccount, scopes)
+  }
+
+  /** Create Google credentials from remote source. The main use-case of this credentials is
+    * Workload Identity Federation.
+    */
+  private[auth] def fromURL[F[_]](
+      client: Client[F],
+      projectId: String,
+      impersonationURL: Option[Uri],
+      urlSource: ExternalCredentialSource.Url,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = (urlSource, impersonationURL) match {
+    case (u, Some(url)) => withImpersonation(client, projectId, url, u, externalAccount, scopes)
+    case (u, None) => withoutImpersonation(client, projectId, u, externalAccount, scopes)
+  }
+
+  private[auth] def forAWS[F[_]](
+      client: Client[F],
+      projectId: String,
+      impersonationURL: Option[Uri],
+      urlSource: ExternalCredentialSource.Aws,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = ???
+
+  private def withoutImpersonation[F[_]: Files](
+      client: Client[F],
+      pid: String,
+      fileSource: ExternalCredentialSource.File,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = fileSource match {
+    case ExternalCredentialSource.File(file, format) =>
+      F.ifM(Files[F].exists(Path(file)))(
+        F.unit,
+        F.raiseError(new IOException(s"$file not found")),
+      ).flatMap(_ =>
+        withoutImpersonation(
+          client,
+          pid,
+          subjectTokenFromFile(file, format),
+          externalAccount,
+          scopes,
+        ),
+      )
+  }
+  private def withoutImpersonation[F[_]](
+      client: Client[F],
+      pid: String,
+      urlSource: ExternalCredentialSource.Url,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = urlSource match {
+    case ExternalCredentialSource.Url(url, headers, format) =>
+      F.fromEither(Uri.fromString(url))
+        .flatMap(url =>
+          withoutImpersonation(
+            client,
+            pid,
+            subjectTokenFromUrl(client, url, headers, format),
+            externalAccount,
+            scopes,
+          ),
+        )
+  }
+
+  /** The shared routine to fetch external credentials without service account impersonation.
+    *
+    * @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    *
+    * @return
+    *   a sts token for authorization skipping impersonation flow
+    */
+  private def withoutImpersonation[F[_]](
+      client: Client[F],
+      pid: String,
+      retrieveSubjectToken: F[String],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = for {
+    // TODO: implement cache logic
+    _ <- F.ref(Option.empty[AccessToken])
+  } yield new GoogleCredentials[F] {
+    def projectId: String = pid
+    def get: F[AccessToken] = for {
+      sbjTkn <- retrieveSubjectToken
+      tkn <- GoogleOAuth2TokenExchange[F](client)
+        .stsToken(sbjTkn, externalAccount, scopes)
+      // If impersonation url is not available, end the flow and just use the STS access token for authorization.
+    } yield tkn
+  }
+
+  private def withImpersonation[F[_]: Files](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      fileSource: ExternalCredentialSource.File,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = fileSource match {
+    case ExternalCredentialSource.File(file, format) =>
+      F.ifM(Files[F].exists(Path(file)))(
+        F.unit,
+        F.raiseError(new IOException(s"$file not found")),
+      ).flatMap(_ =>
+        withImpersonation(
+          client,
+          id,
+          impersonationURL,
+          subjectTokenFromFile(file, format),
+          externalAccount,
+          scopes,
+        ),
+      )
+  }
+  private def withImpersonation[F[_]](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      urlSource: ExternalCredentialSource.Url,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = urlSource match {
+    case ExternalCredentialSource.Url(tknURL, headers, format) =>
+      F.fromEither(Uri.fromString(tknURL))
+        .flatMap(tknURL =>
+          withImpersonation(
+            client,
+            id,
+            impersonationURL,
+            subjectTokenFromUrl(client, tknURL, headers, format),
+            externalAccount,
+            scopes,
+          ),
+        )
+  }
+
+  /** The shared routine to fetch external credentials with service account impersonation
+    *
+    * @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    * @return
+    *   authorization token with impersonation
+    */
+  private def withImpersonation[F[_]](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      retrieveSubjectToken: F[String],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] =
+    for {
+      // TODO: implement cache logic
+      _ <- F.ref(Option.empty[AccessToken])
+    } yield new GoogleCredentials[F] {
+      def projectId: String = id
+      def get: F[AccessToken] =
+        for {
+          sbjTkn <- retrieveSubjectToken
+          // > If service account impersonation is used, the cloud platform or IAM scope should be passed to STS
+          stsTkn <- GoogleOAuth2TokenExchange[F](client).stsToken(
+            sbjTkn,
+            externalAccount,
+            PLATFORM_SCOPES,
+          )
+          // TODO: use service_account_impersonation.token_lifetime_seconds to set token cache life cycle
+
+          // > and then customer provided scopes should be passed in the IamCredentials call
+          req = Request[F]()
+            .withMethod(Method.POST)
+            .withHeaders(Authorization(stsTkn.headerValue))
+            .withUri(impersonationURL)
+            .withEntity(
+              JsonObject(
+                "scopes" -> Json
+                  .fromString(scopes.mkString(",")),
+              ), // If there's service_account_impersonation.token_lifetime_seconds, it needs to be passed here.
+            )(jsonEncoderOf[F, JsonObject])
+          iamTkn <- client.expect[IamCredentialsTokenResponse](req)
+        } yield stsTkn.withToken(iamTkn.accessToken)
+    }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
@@ -208,4 +208,3 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
       scopes,
     )
 }
-

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
@@ -1,0 +1,86 @@
+package org.http4s
+package googleapis.runtime.auth
+import cats.effect.Concurrent
+import cats.effect.Temporal
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.generic.semiauto.deriveDecoder
+import org.http4s.circe.jsonEncoderOf
+import org.http4s.circe.jsonOf
+
+import client.Client
+import headers.Authorization
+
+object ImpersonatedCredentials {
+  private final val PLATFORM_SCOPES = Seq("https://www.googleapis.com/auth/cloud-platform")
+  // private final val IAM_SCOPES = Seq("https://www.googleapis.com/auth/iam")
+  /** The shared routine to fetch external credentials with service account impersonation
+    *
+    * @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    * @return
+    *   authorization token with impersonation
+    */
+  def apply[F[_]](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      retrieveSubjectToken: F[String],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] =
+    for {
+      // TODO: implement cache logic
+      _ <- F.ref(Option.empty[AccessToken])
+    } yield new GoogleCredentials[F] {
+      def projectId: String = id
+      def get: F[AccessToken] =
+        for {
+          sbjTkn <- retrieveSubjectToken
+          // > If service account impersonation is used, the cloud platform or IAM scope should be passed to STS
+          stsTkn <- GoogleOAuth2TokenExchange[F](client).stsToken(
+            sbjTkn,
+            externalAccount,
+            PLATFORM_SCOPES,
+          )
+          // TODO: use service_account_impersonation.token_lifetime_seconds to set token cache life cycle
+
+          // > and then customer provided scopes should be passed in the IamCredentials call
+          req = Request[F]()
+            .withMethod(Method.POST)
+            .withHeaders(Authorization(stsTkn.headerValue))
+            .withUri(impersonationURL)
+            .withEntity(
+              JsonObject(
+                "scopes" -> Json
+                  .fromString(scopes.mkString(",")),
+              ), // If there's service_account_impersonation.token_lifetime_seconds, it needs to be passed here.
+            )(jsonEncoderOf[F, JsonObject])
+          iamTkn <- client.expect[IamCredentialsTokenResponse](req)
+        } yield stsTkn.withToken(iamTkn.accessToken)
+    }
+}
+
+/** @param accessToken
+  *   access token
+  * @param expireTime
+  *   DateTime string in utc
+  */
+private case class IamCredentialsTokenResponse(
+    accessToken: String, // SecretValue,
+    expireTime: String,
+)
+
+private object IamCredentialsTokenResponse {
+  implicit def ed[F[_]: Concurrent]: EntityDecoder[F, IamCredentialsTokenResponse] =
+    jsonOf[F, IamCredentialsTokenResponse]
+  implicit val ev: Decoder[IamCredentialsTokenResponse] = deriveDecoder
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s
 package googleapis.runtime.auth
 import cats.effect.Concurrent

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.http4s
 package googleapis.runtime.auth
 
 import scodec.bits.ByteVector
-
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,7 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
-
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,8 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
 
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(


### PR DESCRIPTION
See https://google.aip.dev/auth/4117

This PR adds external account auth mechanism for file, url and AWS described in https://google.aip.dev/auth/4117

depends on #11 