### PR TITLE
2-0: Feat/support workload identity federation auth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 ThisBuild / tlBaseVersion := "0.0"
 
-ThisBuild / organization := "io.chrisdavenport"
-ThisBuild / organizationName := "Christopher Davenport"
+ThisBuild / organization := "dev.i10416"
+ThisBuild / organizationName := "Yoichiro Ito"
 ThisBuild / developers := List(
+  tlGitHubDev("i10416", "Yoichiro Ito"),
   tlGitHubDev("christopherdavenport", "Christopher Davenport"),
   tlGitHubDev("armanbilge", "Arman Bilge"),
 )

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ ThisBuild / scalaVersion := Scala213
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 val http4sVersion = "0.23.23"
-
+val circeVersion = "0.14.6"
 lazy val root = tlCrossRootProject.aggregate(runtime)
 
 lazy val runtime = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -27,5 +27,8 @@ lazy val runtime = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "cats-effect" % "3.5.2",
       "org.http4s" %%% "http4s-client" % http4sVersion,
       "org.http4s" %%% "http4s-circe" % http4sVersion,
+      "io.circe" %%% "circe-core" % circeVersion,
+      "io.circe" %%% "circe-generic" % circeVersion,
+      "io.circe" %%% "circe-parser" % circeVersion,
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),
 )
 ThisBuild / tlCiReleaseBranches := Seq("main")
-ThisBuild / tlSonatypeUseLegacyHost := true
+//ThisBuild / tlSonatypeUseLegacyHost := true
 
 val Scala213 = "2.13.12"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.1")

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 ThisBuild / tlBaseVersion := "0.0"
 
-ThisBuild / organization := "dev.i10416"
-ThisBuild / organizationName := "Yoichiro Ito"
+ThisBuild / organization := "io.chrisdavenport"
+ThisBuild / organizationName := "Christopher Davenport"
 ThisBuild / developers := List(
-  tlGitHubDev("i10416", "Yoichiro Ito"),
   tlGitHubDev("christopherdavenport", "Christopher Davenport"),
   tlGitHubDev("armanbilge", "Arman Bilge"),
+  tlGitHubDev("i10416", "Yoichiro Ito"),
 )
 ThisBuild / tlCiReleaseBranches := Seq("main")
-//ThisBuild / tlSonatypeUseLegacyHost := true
+ThisBuild / tlSonatypeUseLegacyHost := true
 
 val Scala213 = "2.13.12"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.1")

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -17,11 +17,11 @@
 package org.http4s
 package googleapis.runtime
 
-import cats.effect.kernel.Temporal
-import org.http4s.client.Client
-import org.http4s.googleapis.runtime.auth.AccessToken
-import org.http4s.syntax.all._
-import org.typelevel.ci._
+import cats.effect.Temporal
+
+import client.Client
+import auth.AccessToken
+import syntax.all._
 
 trait ComputeMetadata[F[_]] {
   def getProjectId: F[String]
@@ -31,12 +31,17 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+  def getIdToken(audience: String): F[String]
 }
 
 object ComputeMetadata {
-  def apply[F[_]: Temporal](client: Client[F]): ComputeMetadata[F] =
+  def apply[F[_]: Temporal](
+      client: Client[F],
+      scopes: Set[String],
+      account: String = "default",
+  ): ComputeMetadata[F] =
     new ComputeMetadata[F] {
-      val headers = Headers(Header.Raw(ci"Metadata-Flavor", "Google"))
+      val headers = Headers("Metadata-Flavor" -> "Google")
       val baseUri: Uri = uri"http://metadata.google.internal/computeMetadata/v1"
       def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
 
@@ -48,20 +53,21 @@ object ComputeMetadata {
       val getClusterName = get("instance/attributes/cluster-name")
       val getContainerName = get("instance/attributes/container-name")
       val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
-    }
-}
-Metadata/v1"
-      def mkRequest(path: String) = Request[F](uri = baseUri / path, headers = headers)
+      val getAccessToken = {
+        val base = baseUri / "instance" / "service-accounts" / account / "token"
+        val uri = if (scopes.isEmpty) {
+          base
+        } else {
+          base.withQueryParam("scopes", scopes.mkString(","))
+        }
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
 
-      def get(path: String) = client.expect[String](mkRequest(path))
+      def getIdToken(audience: String) = {
+        val uri = (baseUri / "instance" / "service-accounts" / account / "identity")
+          .withQueryParam("audience", audience)
 
-      val getProjectId = get("project/project-id")
-      val getZone = get("instance/zone")
-      val getInstanceId = get("instance/id")
-      val getClusterName = get("instance/attributes/cluster-name")
-      val getContainerName = get("instance/attributes/container-name")
-      val getNamespaceId = get("instance/attributes/namespace-id")
-      val getAccessToken = client.expect("instance/service-accounts/default/token")
+        client.expect(Request[F](uri = uri, headers = headers))
+      }
     }
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/ComputeMetadata.scala
@@ -31,6 +31,11 @@ trait ComputeMetadata[F[_]] {
   def getContainerName: F[String]
   def getNamespaceId: F[String]
   def getAccessToken: F[AccessToken]
+
+  /** Returns a Google ID Token from the metadata server on ComputeEngine
+    * @param audience
+    *   the aud: field the IdToken should include
+    */
   def getIdToken(audience: String): F[String]
 }
 

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -17,7 +17,9 @@
 package org.http4s
 package googleapis.runtime.auth
 
+import cats.Functor
 import cats.data.EitherT
+import cats.effect.Clock
 import cats.effect.kernel.Temporal
 import cats.syntax.all._
 import io.circe.Decoder
@@ -28,6 +30,8 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
+  def expiresSoon[F[_]: Functor: Clock](in: FiniteDuration = 1.minute): F[Boolean] =
+    Clock[F].realTime.map(now => expiresAt < now + in)
 }
 
 object AccessToken {

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -30,6 +30,8 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
+  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
+  private[auth] def withToken(token: String): AccessToken
   def expiresSoon[F[_]: Functor: Clock](in: FiniteDuration = 1.minute): F[Boolean] =
     Clock[F].realTime.map(now => expiresAt < now + in)
 }
@@ -37,6 +39,8 @@ sealed abstract class AccessToken private {
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
+    override private[auth] def withToken(newToken: String): AccessToken =
+      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -28,15 +28,11 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
-  private[auth] def withToken(token: String): AccessToken
-  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
 }
 
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
-    override private[auth] def withToken(newToken: String): AccessToken =
-      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -28,11 +28,15 @@ import scala.concurrent.duration._
 sealed abstract class AccessToken private {
   def token: String
   def expiresAt: FiniteDuration
+  private[auth] def withToken(token: String): AccessToken
+  private[auth] def headerValue = Credentials.Token(AuthScheme.Bearer, token)
 }
 
 object AccessToken {
   private case class Impl(token: String, expiresAt: FiniteDuration) extends AccessToken {
     override def productPrefix = "AccessToken"
+    override private[auth] def withToken(newToken: String): AccessToken =
+      apply(newToken, expiresAt)
   }
 
   private def apply(token: String, expiresAt: FiniteDuration): AccessToken =

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/AccessToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -155,7 +155,7 @@ object CredentialsFile {
       implicit val ev: Decoder[ExternalCredentialUrlFormat] =
         Decoder
           .withReattempt(cursor =>
-            cursor.downField("type").as[String] match {
+            cursor.downField("type").as[String].map(_.toLowerCase()) match {
               case Right("json") =>
                 cursor.downField("subject_token_field_name").as[String].map(Json(_))
               case Right("text") => Right(Text)

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -76,9 +76,12 @@ object CredentialsFile {
 
   /** @param audience
     *   the Security Token Service audience, which is usually the fully specified resource name
-    *   of the workload/workforce pool provider
+    *   of the workload/workforce pool provider. This value exists for any credential source.
+    * @param subject_token_type
+    *   This value exists for any credential source.
     * @param token_url
-    *   the Security Token Service token exchange endpoint
+    *   the Security Token Service token exchange endpoint. This value exists for any credential
+    *   source.
     * @param token_info_url
     *   the endpoint used to retrieve account related information. Required for gCloud session
     *   account identification.
@@ -90,7 +93,7 @@ object CredentialsFile {
     *   the project used for quota and billing purposes.
     * @param credential_source
     *   This determines the source to obtain subject token. The value is either Url or File to
-    *   get subject token from.
+    *   get subject token from. This field helps detect the identity provider to use.
     * @param scopes
     *   the scopes to request during the authorization grant.
     */
@@ -114,10 +117,16 @@ object CredentialsFile {
     // #[serde(untagged)]
     object ExternalCredentialSource {
       implicit val ev: Decoder[ExternalCredentialSource] =
-        deriveDecoder[Url]
-          .widen[ExternalCredentialSource] <+> deriveDecoder[File]
-          .widen[ExternalCredentialSource] <+> implicitly[Decoder[Aws]]
-          .widen[ExternalCredentialSource]
+        // > This(file) should take precedence over url when both are provided.
+        deriveDecoder[File]
+          .widen[ExternalCredentialSource] <+>
+          deriveDecoder[Url]
+            .widen[ExternalCredentialSource] <+> implicitly[Decoder[Aws]]
+            .widen[ExternalCredentialSource]
+
+      /** @param url
+        *   a url to obtain subject token from
+        */
       case class Url(
           url: String,
           headers: Option[Map[String, String /*SecretValue*/ ]],
@@ -182,7 +191,7 @@ object CredentialsFile {
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(
-                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    s"Unexpected discriminator value `type`=$value for ExternalCredentialUrlFormat",
                     cursor.history,
                   ),
                 )

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -44,15 +44,23 @@ object CredentialsFile {
     deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
       .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
     /** service account credentials file containing __sensitive__ private key.
+      *
+      * @param client_id
+      *   Client id of the service account
+      * @param client_email
+      *   Client email address of the service account
+      * @param private_key_id
+      *   Private key identifier for the service account
+      * @param scopes
+      *   Scope strings for the APIs to be called.
       */
   final case class ServiceAccount(
       project_id: String,
       client_email: String,
       private val private_key_id: String,
       private[auth] val private_key: String, // SecretValue,
-      private val token_url: String,
-      // #[serde(skip)]
-      scopes: Seq[String],
+      private val token_uri: Option[String],
+      scopes: Option[Seq[String]],
       quota_project_id: Option[String],
   ) extends CredentialsFile
 
@@ -66,20 +74,36 @@ object CredentialsFile {
       `type`: String,
   ) extends CredentialsFile
 
-  /** @param credential_source
+  /** @param audience
+    *   the Security Token Service audience, which is usually the fully specified resource name
+    *   of the workload/workforce pool provider
+    * @param token_url
+    *   the Security Token Service token exchange endpoint
+    * @param token_info_url
+    *   the endpoint used to retrieve account related information. Required for gCloud session
+    *   account identification.
+    * @param service_account_impersonation_url
+    *   the URL for the service account impersonation request. This URL is required for some
+    *   APIs. If this URL is not available, the access token from the Security Token Service is
+    *   used directly. May be null.
+    * @param quota_project_id
+    *   the project used for quota and billing purposes.
+    * @param credential_source
     *   This determines the source to obtain subject token. The value is either Url or File to
     *   get subject token from.
+    * @param scopes
+    *   the scopes to request during the authorization grant.
     */
   final case class ExternalAccount(
       audience: String,
       subject_token_type: String,
       token_url: String,
+      token_info_url: String,
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
       credential_source: ExternalAccount.ExternalCredentialSource,
-      // #[serde(skip)]
-      scopes: Seq[String],
+      scopes: Option[Seq[String]],
   ) extends CredentialsFile
 
   object ExternalAccount {

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -19,6 +19,18 @@ package googleapis.runtime.auth
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+
+/** [[CredentialsFile]] represents Google application credentials file variants.
+  *
+  * CredentialsFile is one of the following;
+  *
+  *   - [[CredentialsFile.ServiceAccount]]: service account credentials file containing
+  *     __sensitive__ private key associated with a service account
+  *   - [[CredentialsFile.User]]: This file contains __sensitive__ oauth2 client secret and
+  *     refresh_token.
+  *   - [[CredentialsFile.ExternalAccount]]: This file contains only non-sensitive information.
+  *     This file is mainly for workload identity federation.
+  */
 sealed trait CredentialsFile extends Product with Serializable {
   def getQuotaProjectId: Option[String] = this match {
     case sa: CredentialsFile.ServiceAccount => sa.quota_project_id
@@ -31,6 +43,8 @@ object CredentialsFile {
   final implicit val ev: Decoder[CredentialsFile] =
     deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
       .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
+    /** service account credentials file containing __sensitive__ private key.
+      */
   final case class ServiceAccount(
       project_id: String,
       client_email: String,
@@ -41,6 +55,9 @@ object CredentialsFile {
       scopes: Seq[String],
       quota_project_id: Option[String],
   ) extends CredentialsFile
+
+  /** This file contains __sensitive__ oauth2 client secret and refresh token
+    */
   final case class User(
       private val client_secret: String, // SecretValue,
       client_id: String,
@@ -78,6 +95,12 @@ object CredentialsFile {
       ) extends ExternalCredentialSource
       // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
     }
+
+    /** Internally tagged union of the following two variants;
+      *
+      *   - `{"type": "json", "subject_token_field_name": "<string>"}`
+      *   - `{"type": "text"}`
+      */
     sealed trait ExternalCredentialUrlFormat
     object ExternalCredentialUrlFormat {
       implicit val ev: Decoder[ExternalCredentialUrlFormat] =
@@ -99,11 +122,18 @@ object CredentialsFile {
           )
           .widen[ExternalCredentialUrlFormat]
 
+      /** This variant indicates token value is JSON format.
+        * @param subject_token_field_name
+        *   This value is used to lookup token value from JSON object in token RPC response
+        */
       case class Json(subject_token_field_name: String) extends ExternalCredentialUrlFormat
+
+      /** This variant indicates token value is plain-text format.
+        */
       case object Text extends ExternalCredentialUrlFormat
     }
   }
-  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long])
+  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long /*u64*/ ])
   object ServiceAccountImpersonationSettings {
     implicit val ev: Decoder[ServiceAccountImpersonationSettings] = deriveDecoder
   }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -84,9 +84,9 @@ object CredentialsFile {
         Decoder
           .withReattempt(cursor =>
             cursor.downField("type").as[String] match {
-              case Right("Json") =>
+              case Right("json") =>
                 cursor.downField("subject_token_field_name").as[String].map(Json(_))
-              case Right("Text") => Right(Text)
+              case Right("text") => Right(Text)
               case Right(value) =>
                 Left(
                   io.circe.DecodingFailure(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+sealed trait CredentialsFile extends Product with Serializable {
+  def getQuotaProjectId: Option[String] = this match {
+    case sa: CredentialsFile.ServiceAccount => sa.quota_project_id
+    case u: CredentialsFile.User => u.quota_project_id
+    case ea: CredentialsFile.ExternalAccount => ea.quota_project_id
+  }
+}
+
+object CredentialsFile {
+  final implicit val ev: Decoder[CredentialsFile] =
+    deriveDecoder[ServiceAccount].widen[CredentialsFile] <+> deriveDecoder[User]
+      .widen[CredentialsFile] <+> deriveDecoder[ExternalAccount].widen[CredentialsFile]
+  final case class ServiceAccount(
+      project_id: String,
+      client_email: String,
+      private val private_key_id: String,
+      private[auth] val private_key: String, // SecretValue,
+      private val token_url: String,
+      // #[serde(skip)]
+      scopes: Seq[String],
+      quota_project_id: Option[String],
+  ) extends CredentialsFile
+  final case class User(
+      private val client_secret: String, // SecretValue,
+      client_id: String,
+      private val refresh_token: String, // SecretValue,
+      quota_project_id: Option[String],
+  ) extends CredentialsFile
+  final case class ExternalAccount(
+      audience: String,
+      subject_token_type: String,
+      token_url: String,
+      service_account_impersonation_url: Option[String],
+      service_account_impersonation: Option[ServiceAccountImpersonationSettings],
+      quota_project_id: Option[String],
+      credential_source: ExternalAccount.ExternalCredentialSource,
+      // #[serde(skip)]
+      scopes: Seq[String],
+  ) extends CredentialsFile
+
+  object ExternalAccount {
+    sealed trait ExternalCredentialSource
+    // #[serde(untagged)]
+    object ExternalCredentialSource {
+      implicit val ev: Decoder[ExternalCredentialSource] =
+        deriveDecoder[Url]
+          .widen[ExternalCredentialSource] <+> deriveDecoder[File]
+          .widen[ExternalCredentialSource]
+      case class Url(
+          url: String,
+          headers: Option[Map[String, String /*SecretValue*/ ]],
+          format: Option[ExternalCredentialUrlFormat],
+      ) extends ExternalCredentialSource
+      case class File(
+          file: String,
+          format: Option[ExternalCredentialUrlFormat],
+      ) extends ExternalCredentialSource
+      // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
+    }
+    sealed trait ExternalCredentialUrlFormat
+    object ExternalCredentialUrlFormat {
+      implicit val ev: Decoder[ExternalCredentialUrlFormat] =
+        Decoder
+          .withReattempt(cursor =>
+            cursor.downField("type").as[String] match {
+              case Right("Json") =>
+                cursor.downField("subject_token_field_name").as[String].map(Json(_))
+              case Right("Text") => Right(Text)
+              case Right(value) =>
+                Left(
+                  io.circe.DecodingFailure(
+                    s"Unexpected descriminator value `type`=$value for ExternalCredentialUrlFormat",
+                    cursor.history,
+                  ),
+                )
+              case Left(e) => Left(e)
+            },
+          )
+          .widen[ExternalCredentialUrlFormat]
+
+      case class Json(subject_token_field_name: String) extends ExternalCredentialUrlFormat
+      case object Text extends ExternalCredentialUrlFormat
+    }
+  }
+  case class ServiceAccountImpersonationSettings(token_lifetime_seconds: Option[Long])
+  object ServiceAccountImpersonationSettings {
+    implicit val ev: Decoder[ServiceAccountImpersonationSettings] = deriveDecoder
+  }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -71,6 +71,12 @@ object CredentialsFile {
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
+      /** This determines the source to obtain subject token. The value is one of the
+        * followings;
+        *
+        *   - Url: The client should send http request to the url to get subject token
+        *   - File: There's a local file that contains subject token
+        */
       credential_source: ExternalAccount.ExternalCredentialSource,
       // #[serde(skip)]
       scopes: Seq[String],

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -64,6 +64,11 @@ object CredentialsFile {
       private val refresh_token: String, // SecretValue,
       quota_project_id: Option[String],
   ) extends CredentialsFile
+
+  /** @param credential_source
+    *   This determines the source to obtain subject token. The value is either Url or File to
+    *   get subject token from.
+    */
   final case class ExternalAccount(
       audience: String,
       subject_token_type: String,
@@ -71,12 +76,6 @@ object CredentialsFile {
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],
-      /** This determines the source to obtain subject token. The value is one of the
-        * followings;
-        *
-        *   - Url: The client should send http request to the url to get subject token
-        *   - File: There's a local file that contains subject token
-        */
       credential_source: ExternalAccount.ExternalCredentialSource,
       // #[serde(skip)]
       scopes: Seq[String],

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -63,6 +63,7 @@ object CredentialsFile {
       client_id: String,
       private val refresh_token: String, // SecretValue,
       quota_project_id: Option[String],
+      `type`: String,
   ) extends CredentialsFile
 
   /** @param credential_source

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -114,7 +114,6 @@ object CredentialsFile {
     /** Base credential source class. Dictates the retrieval method of the external credential.
       */
     sealed trait ExternalCredentialSource
-    // #[serde(untagged)]
     object ExternalCredentialSource {
       implicit val ev: Decoder[ExternalCredentialSource] =
         // > This(file) should take precedence over url when both are provided.
@@ -171,7 +170,6 @@ object CredentialsFile {
                 )
             }
       }
-      // AWS external source implementation example https://github.com/googleapis/google-auth-library-nodejs/blob/4bbd13fbf9081e004209d0ffc336648cff0c529e/src/auth/awsclient.ts
     }
 
     /** Internally tagged union of the following two variants;

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountCredentials.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.effect.Temporal
+import cats.syntax.all._
+import fs2.io.IOException
+import fs2.io.file.Files
+import org.http4s.googleapis.runtime.auth.CredentialsFile.ExternalAccount.ExternalCredentialSource
+
+import client.Client
+
+/** External account credentials(A.K.A Workload Identity Federation) implementation to access
+  * Google cloud resources from non-Google cloud platforms.
+  *
+  * @see
+  *   https://google.aip.dev/auth/4117
+  */
+object ExternalAccountCredentials {
+  final val DEFAULT_SCOPES = Seq("https://www.googleapis.com/auth/cloud-platform")
+
+  /** Create Google credentials for external account. Internally, ExternalAccountCredentials has
+    * the following variants
+    *
+    *   - IdentityPoolCredentials with and without service account impersonation from file or
+    *     url source
+    *   - AwsCredentials with service account impersonation
+    *   - Plug-ableAuthCredentials
+    *
+    * @param externalAccount
+    *   credentials file to create ExternalAccountCredentials
+    * @param scopes
+    *   optional scope override. When it is empty, it uses scopes in credentials configuration
+    *   file or fallbacks to `DEFAULT_SCOPES`.
+    */
+  def apply[F[_]: Files](
+      client: Client[F],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Option[Seq[String]] = None,
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = {
+    val pid: F[String] = externalAccount.quota_project_id match {
+      case Some(id) => F.pure(id)
+      case None => ??? // fetch from metadata server?
+    }
+
+    for {
+      id <- pid
+      theScopes = scopes.orElse(externalAccount.scopes).getOrElse(DEFAULT_SCOPES)
+      impersonationURL <- externalAccount.service_account_impersonation_url.traverse(
+        Uri.fromString.andThen(F.fromEither),
+      )
+      // > check `credentials_source` to determine the necessary logic to retrieve the external credential
+      credentials <-
+        (externalAccount.credential_source, impersonationURL) match {
+          case (_: ExternalCredentialSource.Aws, None) =>
+            F.raiseError(
+              new IOException("AWS credentials need service_account_impersonation_url"),
+            )
+          case (f: ExternalCredentialSource.File, impersonationURL) =>
+            IdentityPoolCredentials.fromFile(
+              client,
+              id,
+              impersonationURL,
+              f,
+              externalAccount,
+              theScopes,
+            )
+          case (u: ExternalCredentialSource.Url, impersonationURL) =>
+            IdentityPoolCredentials.fromURL(
+              client,
+              id,
+              impersonationURL,
+              u,
+              externalAccount,
+              theScopes,
+            )
+          case (_: ExternalCredentialSource.Aws, Some(_)) =>
+            F.raiseError(new NotImplementedError("AwsCredentials is not implemented yet."))
+        }
+    } yield credentials
+  }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountSubjectTokenProvider.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountSubjectTokenProvider.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.io.file.Files
+import fs2.io.file.Path
+import io.circe.Decoder
+import io.circe.parser
+import org.http4s.circe.jsonOf
+
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.Text
+import CredentialsFile.ExternalAccount.ExternalCredentialUrlFormat.{Json => JsonFmt}
+import client.Client
+private[auth] trait ExternalAccountSubjectTokenProvider {
+  private[auth] def subjectTokenFromUrl[F[_]](
+      client: Client[F],
+      url: Uri,
+      headers: Option[Map[String, String]],
+      format: Option[ExternalCredentialUrlFormat],
+  )(implicit F: Concurrent[F]) = {
+    val headerList = headers.getOrElse(Map.empty).toList
+    val hs = Headers(headerList)
+    val req = Request[F](uri = url).putHeaders(hs)
+    format match {
+      // > If the format is not available, assume the external credential is provided in plain text format
+      case None | Some(Text) => client.expect[String](req)
+      case Some(JsonFmt(subjectTokenFieldName)) =>
+        val dec = Decoder.forProduct1[String, String](subjectTokenFieldName)(identity)
+        client.expect[String](req)(jsonOf(F, dec))
+    }
+  }
+  private[auth] def subjectTokenFromFile[F[_]: Files](
+      file: String,
+      format: Option[ExternalCredentialUrlFormat],
+  )(implicit F: Concurrent[F]) = for {
+    tokenOrJson <- Files[F].readUtf8(Path(file)).compile.string
+    tkn <- format match {
+      // > If the format is not available, assume the external credential is provided in plain text format
+      case None | Some(Text) => F.pure(tokenOrJson)
+      case Some(JsonFmt(subjectTokenFieldName)) =>
+        val dec = Decoder.forProduct1[String, String](subjectTokenFieldName)(identity)
+        F.fromEither(parser.parse(tokenOrJson).flatMap(dec.decodeJson(_)))
+    }
+  } yield tkn
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Yoichiro Ito
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.googleapis.runtime.auth
+
+trait GoogleCredentials[F[_]] {
+  def projectId: String
+  def get: F[AccessToken]
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.googleapis.runtime.auth
+
+trait GoogleCredentials[F[_]] {
+  def projectId: String
+  def get: F[AccessToken]
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2JwtBearer.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2JwtBearer.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+
+import scodec.bits.ByteVector
+
+trait GoogleOAuth2JwtBearer[F[_]] {
+  def getAccessToken(
+      clientEmail: String,
+      privateKey: ByteVector,
+      scopes: Seq[String],
+  ): F[AccessToken]
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleOAuth2TokenExchage.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+
+import cats.effect.Temporal
+import io.circe.Json
+import io.circe.JsonObject
+import org.http4s.circe.jsonEncoderOf
+
+import googleapis.runtime.auth.CredentialsFile.ExternalAccount
+import client.Client
+trait GoogleOAuth2TokenExchange[F[_]] {
+
+  /** Exchanges the external credential for a Google Cloud access token.
+    * @param subjectToken
+    *   retrieved external credentials
+    * @param scopes
+    *   a list of OAuth scopes that specify the desired scopes of the requested security token
+    *   in the context of the service or resource where the token should be used. If service
+    *   account impersonation is used, the cloud platform or IAM scope should be passed.
+    * @param requestOverride
+    *   A hack to support Secure Token Service that requires dedicated handling. For example,
+    *   AWS STS requires `x-goog-cloud-endpoint` header.
+    * @return
+    *   the access token returned by the Security Token Service
+    */
+  def stsToken(
+      subjectToken: String,
+      externalAccount: ExternalAccount,
+      scopes: Seq[String],
+      requestOverride: Request[F] => Request[F] = identity,
+  ): F[AccessToken]
+}
+
+object GoogleOAuth2TokenExchange {
+  def apply[F[_]: Temporal](client: Client[F]) =
+    new GoogleOAuth2TokenExchange[F] {
+      private val je: EntityEncoder[F, JsonObject] = jsonEncoderOf[F, JsonObject]
+      def stsToken(
+          subjectToken: String,
+          externalAccount: ExternalAccount,
+          scopes: Seq[String],
+          requestOverride: Request[F] => Request[F] = identity,
+      ): F[AccessToken] = {
+        val req = Request[F](uri = Uri.unsafeFromString(externalAccount.token_url))
+          .withEntity(
+            JsonObject(
+              "grant_type" -> Json.fromString(
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+              ),
+              "audience" -> Json.fromString(externalAccount.audience),
+              "requested_token_type" -> Json.fromString(
+                "urn:ietf:params:oauth:token-type:access_token",
+              ),
+              "subject_token_type" -> Json.fromString(externalAccount.subject_token_type),
+              "subject_token" -> Json.fromString(subjectToken),
+              "scope" -> Json.fromString(scopes.mkString(" ")),
+            ),
+          )(je)
+        client.expect[AccessToken](requestOverride(req))
+      }
+    }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+
+import cats.effect.Temporal
+import cats.syntax.all._
+
+import client.Client
+import CredentialsFile.ExternalAccount.ExternalCredentialSource
+import fs2.io.file.Files
+import fs2.io.file.Path
+import fs2.io.IOException
+
+object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
+
+  /** Create Google credentials from local file. The main use-case of this credentials is
+    * Workload Identity Federation. This function may fail when no file is found at file source.
+    */
+  private[auth] def fromFile[F[_]: Files](
+      client: Client[F],
+      projectId: String,
+      impersonationURL: Option[Uri],
+      fileSource: ExternalCredentialSource.File,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = (fileSource, impersonationURL) match {
+    case (file, Some(url)) =>
+      withImpersonation(client, projectId, url, file, externalAccount, scopes)
+    case (file, None) => withoutImpersonation(client, projectId, file, externalAccount, scopes)
+  }
+
+  /** Create Google credentials from remote source. The main use-case of this credentials is
+    * Workload Identity Federation.
+    */
+  private[auth] def fromURL[F[_]](
+      client: Client[F],
+      projectId: String,
+      impersonationURL: Option[Uri],
+      urlSource: ExternalCredentialSource.Url,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = (urlSource, impersonationURL) match {
+    case (u, Some(url)) => withImpersonation(client, projectId, url, u, externalAccount, scopes)
+    case (u, None) => withoutImpersonation(client, projectId, u, externalAccount, scopes)
+  }
+
+  private def withoutImpersonation[F[_]: Files](
+      client: Client[F],
+      pid: String,
+      fileSource: ExternalCredentialSource.File,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = fileSource match {
+    case ExternalCredentialSource.File(file, format) =>
+      F.ifM(Files[F].exists(Path(file)))(
+        F.unit,
+        F.raiseError(new IOException(s"$file not found")),
+      ).flatMap(_ =>
+        withoutImpersonation(
+          client,
+          pid,
+          subjectTokenFromFile(file, format),
+          externalAccount,
+          scopes,
+        ),
+      )
+  }
+  private def withoutImpersonation[F[_]](
+      client: Client[F],
+      pid: String,
+      urlSource: ExternalCredentialSource.Url,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = urlSource match {
+    case ExternalCredentialSource.Url(url, headers, format) =>
+      F.fromEither(Uri.fromString(url))
+        .flatMap(url =>
+          withoutImpersonation(
+            client,
+            pid,
+            subjectTokenFromUrl(client, url, headers, format),
+            externalAccount,
+            scopes,
+          ),
+        )
+  }
+
+  /** The shared routine to fetch external credentials without service account impersonation.
+    *
+    * @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    *
+    * @return
+    *   a sts token for authorization skipping impersonation flow
+    */
+  private def withoutImpersonation[F[_]](
+      client: Client[F],
+      pid: String,
+      retrieveSubjectToken: F[String],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = for {
+    // TODO: implement cache logic
+    _ <- F.ref(Option.empty[AccessToken])
+  } yield new GoogleCredentials[F] {
+    def projectId: String = pid
+    def get: F[AccessToken] = for {
+      sbjTkn <- retrieveSubjectToken
+      tkn <- GoogleOAuth2TokenExchange[F](client)
+        .stsToken(sbjTkn, externalAccount, scopes)
+      // If impersonation url is not available, end the flow and just use the STS access token for authorization.
+    } yield tkn
+  }
+
+  private def withImpersonation[F[_]: Files](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      fileSource: ExternalCredentialSource.File,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = fileSource match {
+    case ExternalCredentialSource.File(file, format) =>
+      F.ifM(Files[F].exists(Path(file)))(
+        F.unit,
+        F.raiseError(new IOException(s"$file not found")),
+      ).flatMap(_ =>
+        withImpersonation(
+          client,
+          id,
+          impersonationURL,
+          subjectTokenFromFile(file, format),
+          externalAccount,
+          scopes,
+        ),
+      )
+  }
+  private def withImpersonation[F[_]](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      urlSource: ExternalCredentialSource.Url,
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = urlSource match {
+    case ExternalCredentialSource.Url(tknURL, headers, format) =>
+      F.fromEither(Uri.fromString(tknURL))
+        .flatMap(tknURL =>
+          withImpersonation(
+            client,
+            id,
+            impersonationURL,
+            subjectTokenFromUrl(client, tknURL, headers, format),
+            externalAccount,
+            scopes,
+          ),
+        )
+  }
+
+  /** The shared routine to fetch external credentials with service account impersonation
+    *
+    * @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    * @return
+    *   authorization token with impersonation
+    */
+  private def withImpersonation[F[_]](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      retrieveSubjectToken: F[String],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] =
+    ImpersonatedCredentials(
+      client,
+      id,
+      impersonationURL,
+      retrieveSubjectToken,
+      externalAccount,
+      scopes,
+    )
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.effect.Concurrent
+import cats.effect.Temporal
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.generic.semiauto.deriveDecoder
+import org.http4s.circe.jsonEncoderOf
+import org.http4s.circe.jsonOf
+
+import client.Client
+import headers.Authorization
+
+object ImpersonatedCredentials {
+  private final val PLATFORM_SCOPES = Seq("https://www.googleapis.com/auth/cloud-platform")
+  // private final val IAM_SCOPES = Seq("https://www.googleapis.com/auth/iam")
+  /** The shared routine to fetch external credentials with service account impersonation
+    *
+    * @param id
+    *   GCP project id
+    * @param retrieveSubjectToken
+    *   abstract platform specific actions to retrieve subject token for token exchange
+    * @param externalAccount
+    *   configuration for external account credentials generation
+    * @param scopes
+    *   scopes for authorization
+    * @return
+    *   authorization token with impersonation
+    */
+  def apply[F[_]](
+      client: Client[F],
+      id: String,
+      impersonationURL: Uri,
+      retrieveSubjectToken: F[String],
+      externalAccount: CredentialsFile.ExternalAccount,
+      scopes: Seq[String],
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] =
+    for {
+      // TODO: implement cache logic
+      _ <- F.ref(Option.empty[AccessToken])
+    } yield new GoogleCredentials[F] {
+      def projectId: String = id
+      def get: F[AccessToken] =
+        for {
+          sbjTkn <- retrieveSubjectToken
+          // > If service account impersonation is used, the cloud platform or IAM scope should be passed to STS
+          stsTkn <- GoogleOAuth2TokenExchange[F](client).stsToken(
+            sbjTkn,
+            externalAccount,
+            PLATFORM_SCOPES,
+          )
+          // TODO: use service_account_impersonation.token_lifetime_seconds to set token cache life cycle
+
+          // > and then customer provided scopes should be passed in the IamCredentials call
+          req = Request[F]()
+            .withMethod(Method.POST)
+            .withHeaders(Authorization(stsTkn.headerValue))
+            .withUri(impersonationURL)
+            .withEntity(
+              JsonObject(
+                "scopes" -> Json
+                  .fromString(scopes.mkString(",")),
+              ), // If there's service_account_impersonation.token_lifetime_seconds, it needs to be passed here.
+            )(jsonEncoderOf[F, JsonObject])
+          iamTkn <- client.expect[IamCredentialsTokenResponse](req)
+        } yield stsTkn.withToken(iamTkn.accessToken)
+    }
+}
+
+/** @param accessToken
+  *   access token
+  * @param expireTime
+  *   DateTime string in utc
+  */
+private case class IamCredentialsTokenResponse(
+    accessToken: String, // SecretValue,
+    expireTime: String,
+)
+
+private object IamCredentialsTokenResponse {
+  implicit def ed[F[_]: Concurrent]: EntityDecoder[F, IamCredentialsTokenResponse] =
+    jsonOf[F, IamCredentialsTokenResponse]
+  implicit val ev: Decoder[IamCredentialsTokenResponse] = deriveDecoder
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/Jwt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.http4s
 package googleapis.runtime.auth
 
 import scodec.bits.ByteVector
-
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Christopher Davenport
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,7 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
-
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -17,14 +17,8 @@
 package org.http4s
 package googleapis.runtime.auth
 
-import cats.data.EitherT
-import cats.effect.kernel.Temporal
-import cats.syntax.all._
-import io.circe.Decoder
-import org.http4s.circe.jsonOf
 import scodec.bits.ByteVector
 
-import scala.concurrent.duration._
 
 trait OAuth2[F[_]] {
   def getAccessToken(

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Christopher Davenport
+ * Copyright 2024 Yoichiro Ito
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Yoichiro Ito
+ * Copyright 2024 Christopher Davenport
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Yoichiro Ito
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package googleapis.runtime.auth
+import cats.data.OptionT
+import cats.effect.Temporal
+import cats.syntax.all._
+import org.http4s.googleapis.runtime.auth.CredentialsFile.ExternalAccount
+import org.http4s.googleapis.runtime.auth.CredentialsFile.ServiceAccount
+import org.http4s.googleapis.runtime.auth.CredentialsFile.User
+
+import scala.annotation.nowarn
+
+import client.Client
+
+object Oauth2Credentials {
+  val DEFAULT_SCOPES = Seq("https://www.googleapis.com/auth/cloud-platform")
+
+  /** setup GoogleCredentials from configuration file.
+    *
+    * @param credentialsFile
+    *   Google credential file for authentication
+    * @param scopesOverride
+    *   optional OAuth2 scopes override. Default is `DEFAULT_SCOPES`.
+    * @param quotaProjectOverride
+    *   Quota project id from environment variables. According to
+    *   https://google.aip.dev/auth/4110#environment-variables, the value from the environment
+    *   variable will override any quota project that is present in the credential detected by
+    *   the ADC mechanism.
+    *
+    * @see
+    *   https://google.aip.dev/auth/4110#expected-behavior block 2(Load credentials), block 4(
+    *   Determine auth flows) and block 5(Execute auth flows)
+    */
+  @nowarn
+  def apply[F[_]](
+      client: Client[F],
+      credentialsFile: CredentialsFile,
+      scopesOverride: Option[Seq[String]] = None,
+      quotaProjectOverride: Option[String] = None,
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = {
+    val _ = scopesOverride.getOrElse(DEFAULT_SCOPES)
+
+    credentialsFile match {
+      case _: User =>
+        // user identity flow to exchange for an access token
+        F.raiseError(
+          new NotImplementedError("User credentials auth is not implemented"),
+        )
+      case _: ServiceAccount =>
+        // self-signed JWT flow for an access token
+        // https://google.aip.dev/auth/4111
+        F.raiseError(
+          new NotImplementedError("ServiceAccount credentials auth is not implemented"),
+        )
+      case _: ExternalAccount =>
+        // external account flow to exchange for an access token
+        // https://google.aip.dev/auth/4117
+        F.raiseError(
+          new NotImplementedError("ExternalAccount credentials auth is not implemented"),
+        )
+    }
+  }
+
+  @nowarn
+  private def apply[F[_]](pid: String, refresh: F[AccessToken])(implicit
+      F: Temporal[F],
+  ): F[GoogleCredentials[F]] =
+    for {
+      cache <- F.ref(Option.empty[F[AccessToken]])
+    } yield new GoogleCredentials[F] {
+      val projectId = pid
+
+      def get: F[AccessToken] = OptionT(cache.get)
+        .semiflatMap(identity)
+        .flatMapF { token =>
+          for {
+            expired <- token.expiresSoon()
+          } yield Option.unless(expired)(token)
+        }
+        .getOrElseF {
+          for {
+            memo <- F.memoize(refresh)
+            updated <- cache.tryUpdate(_ => Some(memo))
+            token <-
+              if (updated) memo
+              else get
+
+          } yield token
+        }
+    }
+}

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
@@ -75,8 +75,7 @@ object Oauth2Credentials {
     }
   }
 
-  @nowarn
-  private def apply[F[_]](pid: String, refresh: F[AccessToken])(implicit
+  private[auth] def apply[F[_]](pid: String, refresh: F[AccessToken])(implicit
       F: Temporal[F],
   ): F[GoogleCredentials[F]] =
     for {


### PR DESCRIPTION
This PR splits https://github.com/davenverse/googleapis-http4s-runtime/pull/12 into smaller changes
See https://google.aip.dev/auth/4117

This PR adds partial support of authentication via workload identity federation.

This commits add file-based and URL-based authentication.

File-based and URL-based authentication cover common usecases such as
authentication between computing instances within GCP and accessing GCP resources from GitHub Actions.

AWS credentials auth is not implemented in this change because it needs additional
crypto dependencies to sign requests using HMac algorithm. Outline of AWS credentials is implemented in https://github.com/davenverse/googleapis-http4s-runtime/pull/12

Example:

```scala
//> using scala "2.13.12"
//> using repositories "sonatype-s01:snapshots"
//> using dep "dev.i10416::http4s-googleapis-runtime:0.0-2f88c52-SNAPSHOT"
//> using dep "org.http4s::http4s-core:0.23.25"
//> using dep "org.http4s::http4s-ember-client:0.23.25"
//> using dep "org.typelevel::cats-effect:3.5.2"

import cats.effect._
import org.http4s.ember.client.EmberClientBuilder
import org.http4s.googleapis.runtime.auth.ApplicationDefaultCredentials
object Main extends IOApp {
  def run(args: List[String]): IO[ExitCode] = EmberClientBuilder
    .default[IO]
    .build
    .use { client =>
      for {
        oauth2 <- ApplicationDefaultCredentials(client)
        tkn <- oauth2.get
        _ <- IO.println(tkn)
      } yield ()

    }
    .handleErrorWith(IO.println(_))
    .as(ExitCode.Success)
}

```

```yaml
name: 'Debug Google OAuth2 External Account Credentials'

on:    
  pull_request:
    branches: [master, main]
    types:
      - opened
      - synchronize
      - reopened
jobs:
  check:
    runs-on: ubuntu-20.04
    permissions:
      contents: 'read'
      id-token: 'write'
    steps:
      - name: checkout
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
      - name: Authenticate to Google Cloud
        id: 'google-cloud-auth'
        uses: 'google-github-actions/auth@v2'
        with:
          token_format: 'access_token'
          workload_identity_provider: GCP_WORKLOAD_ID_PROVIDER_ID
          service_account: GCP_SERVICE_ACCOUNT
          create_credentials_file: true
      - name: 'Set up Cloud SDK'
        uses: 'google-github-actions/setup-gcloud@v2'
      - uses: coursier/cache-action@v6.3
      - uses: VirtusLab/scala-cli-setup@main
      - run: scala-cli .


```